### PR TITLE
feat: implement cps content management frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CPS 推广项目内容管理系统</title>
+  </head>
+  <body class="bg-gray-50 text-gray-900">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "cpsrecord-client",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext .ts,.tsx,.vue",
+    "test:unit": "vitest --environment jsdom"
+  },
+  "dependencies": {
+    "axios": "^1.7.7",
+    "element-plus": "^2.7.8",
+    "@element-plus/icons-vue": "^2.3.1",
+    "pinia": "^2.1.7",
+    "vue": "^3.4.38",
+    "vue-router": "^4.3.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@vitejs/plugin-vue": "^5.0.5",
+    "@vitejs/plugin-vue-jsx": "^4.0.1",
+    "@vue/test-utils": "^2.4.6",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5",
+    "vite": "^5.3.3",
+    "vitest": "^1.6.0",
+    "vue-tsc": "^2.0.21"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#7c3aed" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#grad)" />
+  <path
+    d="M40 88V40h16l16 24 16-24h16v48h-16V64l-16 24-16-24v24H40z"
+    fill="#fff"
+  />
+</svg>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="min-h-screen bg-slate-100">
+    <AppHeader />
+    <main class="max-w-7xl mx-auto px-4 py-6">
+      <router-view />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import AppHeader from "@/components/common/AppHeader.vue";
+</script>

--- a/src/components/common/AppHeader.vue
+++ b/src/components/common/AppHeader.vue
@@ -1,0 +1,75 @@
+<template>
+  <header class="sticky top-0 z-30 bg-white shadow-sm border-b border-slate-200">
+    <div class="max-w-7xl mx-auto flex flex-col gap-3 px-4 py-4 md:flex-row md:items-center md:justify-between">
+      <div class="flex items-center gap-3">
+        <div class="flex h-12 w-12 items-center justify-center rounded-full bg-primary-100 text-primary-600">
+          <el-icon class="text-2xl"><Collection /></el-icon>
+        </div>
+        <div>
+          <h1 class="text-xl font-semibold text-slate-900">CPS 推广项目管理系统</h1>
+          <p class="text-sm text-slate-500">集中管理项目、子项目和推广内容</p>
+        </div>
+      </div>
+
+      <div class="flex flex-1 flex-col gap-3 md:flex-row md:items-center md:justify-end">
+        <div class="flex items-center gap-3 text-sm text-slate-500">
+          <div class="flex items-center gap-1">
+            <el-icon><FolderOpened /></el-icon>
+            <span>项目数：{{ projectStats.totalProjects }}</span>
+          </div>
+          <div class="hidden items-center gap-1 md:flex">
+            <el-icon><Timer /></el-icon>
+            <span>最近更新：{{ projectStats.lastUpdated || "--" }}</span>
+          </div>
+        </div>
+        <nav class="flex items-center gap-2">
+          <RouterLink
+            v-for="item in navItems"
+            :key="item.path"
+            :to="item.path"
+            class="rounded-full px-4 py-2 text-sm font-medium transition"
+            :class="
+              route.path.startsWith(item.match)
+                ? 'bg-primary-600 text-white shadow'
+                : 'text-slate-600 hover:bg-slate-100'
+            "
+          >
+            <component :is="item.icon" class="mr-1" />
+            {{ item.label }}
+          </RouterLink>
+        </nav>
+      </div>
+    </div>
+  </header>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { RouterLink, useRoute } from "vue-router";
+import { useProjects } from "@/composables/useProjects";
+import {
+  Collection,
+  FolderOpened,
+  Timer,
+  List,
+  Files,
+} from "@element-plus/icons-vue";
+
+const route = useRoute();
+const { projectStats } = useProjects();
+
+const navItems = computed(() => [
+  {
+    label: "项目管理",
+    path: "/projects",
+    match: "/projects",
+    icon: List,
+  },
+  {
+    label: "内容类型",
+    path: "/content-types",
+    match: "/content-types",
+    icon: Files,
+  },
+]);
+</script>

--- a/src/components/common/ConfirmDialog.vue
+++ b/src/components/common/ConfirmDialog.vue
@@ -1,0 +1,55 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    :title="title"
+    width="420px"
+    @close="handleCancel"
+  >
+    <div class="flex items-start gap-3">
+      <el-icon class="text-xl text-red-500"><WarningFilled /></el-icon>
+      <div class="space-y-1">
+        <p class="text-base font-medium text-slate-800">{{ description }}</p>
+        <p class="text-sm text-slate-500">{{ subDescription }}</p>
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end gap-3">
+        <el-button @click="handleCancel">取消</el-button>
+        <el-button type="primary" :loading="loading" @click="handleConfirm">
+          {{ confirmText }}
+        </el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { WarningFilled } from "@element-plus/icons-vue";
+
+interface Props {
+  visible: boolean;
+  title?: string;
+  description: string;
+  subDescription?: string;
+  confirmText?: string;
+  loading?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  title: "确认操作",
+  confirmText: "确认",
+  loading: false,
+  subDescription: "该操作不可撤销，请谨慎操作",
+});
+
+const emit = defineEmits<{ (e: "confirm"): void; (e: "cancel"): void }>();
+
+const handleConfirm = () => {
+  emit("confirm");
+};
+
+const handleCancel = () => {
+  emit("cancel");
+};
+</script>

--- a/src/components/common/LoadingSpinner.vue
+++ b/src/components/common/LoadingSpinner.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="flex items-center justify-center py-12 text-slate-500">
+    <el-icon class="mr-2 animate-spin text-xl"><Loading /></el-icon>
+    <span>{{ text }}</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Loading } from "@element-plus/icons-vue";
+
+interface Props {
+  text?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  text: "数据加载中...",
+});
+</script>

--- a/src/components/content/ContentEditor.vue
+++ b/src/components/content/ContentEditor.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="content-editor">
+    <el-form ref="formRef" :model="formData" :rules="rules" label-width="110px" @submit.prevent>
+      <el-form-item label="内容类型" prop="contentTypeId">
+        <el-select v-model="formData.contentTypeId" placeholder="请选择内容类型" @change="handleContentTypeChange">
+          <el-option
+            v-for="type in contentTypes"
+            :key="type.id"
+            :label="type.name"
+            :value="type.id"
+          />
+        </el-select>
+      </el-form-item>
+
+      <el-form-item v-if="selectedContentType?.fieldType === 'text'" label="内容" prop="contentValue">
+        <el-input
+          v-model="formData.contentValue"
+          type="textarea"
+          :autosize="{ minRows: 3, maxRows: 6 }"
+          placeholder="请输入文本内容"
+        />
+      </el-form-item>
+
+      <el-form-item v-else-if="selectedContentType?.fieldType === 'url'" label="链接" prop="contentValue">
+        <el-input v-model="formData.contentValue" placeholder="请输入链接地址" />
+      </el-form-item>
+
+      <el-form-item v-else-if="selectedContentType?.fieldType === 'image'" label="图片" prop="contentValue">
+        <el-upload
+          class="upload-demo"
+          drag
+          :auto-upload="false"
+          accept="image/*"
+          :on-change="handleImageChange"
+        >
+          <el-icon class="el-icon--upload"><UploadFilled /></el-icon>
+          <div class="el-upload__text">拖拽文件到此处或点击上传</div>
+        </el-upload>
+        <p v-if="formData.contentValue" class="mt-2 text-xs text-slate-500">{{ formData.contentValue }}</p>
+      </el-form-item>
+
+      <el-form-item v-if="selectedContentType?.hasExpiry" label="有效天数" prop="expiryDays">
+        <el-input-number v-model="formData.expiryDays" :min="1" :max="180" />
+        <span class="ml-3 text-xs text-slate-500">预估到期：{{ calculatedExpiryDate }}</span>
+      </el-form-item>
+
+      <div class="flex justify-end gap-3 pt-2">
+        <el-button @click="handleCancel">取消</el-button>
+        <el-button type="primary" :loading="submitting" @click="handleSubmit">
+          {{ submitText }}
+        </el-button>
+      </div>
+    </el-form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import type { FormInstance, FormRules, UploadFile } from "element-plus";
+import type { ContentType, SubProjectContent } from "@/types";
+import { UploadFilled } from "@element-plus/icons-vue";
+
+interface Props {
+  contentTypes: ContentType[];
+  modelValue?: SubProjectContent | null;
+  submitting?: boolean;
+  submitText?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: null,
+  submitting: false,
+  submitText: "保存",
+});
+
+const emit = defineEmits<{
+  (e: "submit", payload: { contentTypeId: number; contentValue: string; expiryDays?: number }): void;
+  (e: "cancel"): void;
+}>();
+
+const formRef = ref<FormInstance>();
+const formData = ref({
+  contentTypeId: undefined as number | undefined,
+  contentValue: "",
+  expiryDays: undefined as number | undefined,
+});
+
+const selectedContentType = computed(() =>
+  props.contentTypes.find((type) => type.id === formData.value.contentTypeId)
+);
+
+const calculatedExpiryDate = computed(() => {
+  if (!formData.value.expiryDays) return "--";
+  const date = new Date();
+  date.setDate(date.getDate() + formData.value.expiryDays);
+  return date.toLocaleDateString("zh-CN");
+});
+
+const rules: FormRules = {
+  contentTypeId: [{ required: true, message: "请选择内容类型", trigger: "change" }],
+  contentValue: [{ required: true, message: "请输入内容", trigger: "blur" }],
+  expiryDays: [{ required: true, message: "请输入有效天数", trigger: "blur" }],
+};
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (value) {
+      formData.value = {
+        contentTypeId: value.contentType.id,
+        contentValue: value.contentValue,
+        expiryDays: value.expiryDays,
+      };
+    } else {
+      formData.value = {
+        contentTypeId: undefined,
+        contentValue: "",
+        expiryDays: undefined,
+      };
+    }
+  },
+  { immediate: true }
+);
+
+const handleContentTypeChange = () => {
+  formData.value.contentValue = "";
+  formData.value.expiryDays = undefined;
+};
+
+const handleImageChange = (file: UploadFile) => {
+  if (file.url) {
+    formData.value.contentValue = file.url;
+  } else if (file.raw) {
+    formData.value.contentValue = file.name;
+  }
+};
+
+const handleSubmit = async () => {
+  if (!formRef.value) return;
+  try {
+    await formRef.value.validate();
+    if (!formData.value.contentTypeId) return;
+    emit("submit", {
+      contentTypeId: formData.value.contentTypeId,
+      contentValue: formData.value.contentValue.trim(),
+      expiryDays: formData.value.expiryDays,
+    });
+  } catch (error) {
+    // ignore validation error
+  }
+};
+
+const handleCancel = () => emit("cancel");
+</script>
+
+<style scoped>
+.content-editor {
+  padding: 12px 0;
+}
+</style>

--- a/src/components/content/ContentTypeManager.vue
+++ b/src/components/content/ContentTypeManager.vue
@@ -1,0 +1,185 @@
+<template>
+  <el-card shadow="never" body-class="space-y-4">
+    <template #header>
+      <div class="flex items-center justify-between">
+        <div>
+          <h3 class="text-lg font-semibold text-slate-800">内容类型配置</h3>
+          <p class="text-sm text-slate-500">自定义推广内容类型，支持文本、链接、图片等</p>
+        </div>
+        <el-button type="primary" @click="openDialog()">
+          <el-icon class="mr-1"><Plus /></el-icon>
+          新建内容类型
+        </el-button>
+      </div>
+    </template>
+
+    <el-table :data="contentTypes" border>
+      <el-table-column prop="name" label="名称" width="160" />
+      <el-table-column prop="fieldType" label="字段类型" width="140">
+        <template #default="{ row }">
+          <el-tag type="info">{{ fieldTypeLabels[row.fieldType] }}</el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column prop="hasExpiry" label="是否过期" width="120">
+        <template #default="{ row }">
+          <el-tag :type="row.hasExpiry ? 'warning' : 'success'">
+            {{ row.hasExpiry ? '需要设置有效期' : '长期有效' }}
+          </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column prop="isSystem" label="系统内置" width="120">
+        <template #default="{ row }">
+          <el-tag :type="row.isSystem ? 'info' : 'primary'">
+            {{ row.isSystem ? '系统类型' : '自定义' }}
+          </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column prop="description" label="描述">
+        <template #default="{ row }">
+          <span class="text-sm text-slate-600">{{ row.description || '暂无描述' }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="操作" width="160">
+        <template #default="{ row }">
+          <el-button type="primary" link size="small" @click="openDialog(row)">编辑</el-button>
+          <el-popconfirm
+            v-if="!row.isSystem"
+            title="确定删除该内容类型吗?"
+            confirm-button-text="删除"
+            cancel-button-text="取消"
+            @confirm="handleDelete(row)"
+          >
+            <template #reference>
+              <el-button type="danger" link size="small">删除</el-button>
+            </template>
+          </el-popconfirm>
+        </template>
+      </el-table-column>
+    </el-table>
+  </el-card>
+
+  <el-dialog :title="dialogTitle" :model-value="dialogVisible" width="520px" @close="closeDialog">
+    <el-form ref="formRef" :model="form" :rules="rules" label-width="100px">
+      <el-form-item label="名称" prop="name">
+        <el-input v-model="form.name" maxlength="50" show-word-limit placeholder="内容类型名称" />
+      </el-form-item>
+      <el-form-item label="字段类型" prop="fieldType">
+        <el-select v-model="form.fieldType" placeholder="请选择字段类型">
+          <el-option v-for="item in fieldTypeOptions" :key="item.value" :label="item.label" :value="item.value" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="需要有效期" prop="hasExpiry">
+        <el-switch v-model="form.hasExpiry" />
+      </el-form-item>
+      <el-form-item label="描述">
+        <el-input
+          v-model="form.description"
+          type="textarea"
+          :autosize="{ minRows: 2, maxRows: 4 }"
+          maxlength="120"
+          show-word-limit
+          placeholder="描述该类型使用场景"
+        />
+      </el-form-item>
+    </el-form>
+    <template #footer>
+      <div class="flex justify-end gap-3">
+        <el-button @click="closeDialog">取消</el-button>
+        <el-button type="primary" :loading="submitting" @click="handleSubmit">保存</el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref } from "vue";
+import type { FormInstance, FormRules } from "element-plus";
+import type { ContentType } from "@/types";
+import { Plus } from "@element-plus/icons-vue";
+
+const props = defineProps<{ contentTypes: ContentType[]; submitting?: boolean }>();
+const emit = defineEmits<{
+  (e: "create", payload: { name: string; fieldType: ContentType["fieldType"]; hasExpiry: boolean; description?: string }): void;
+  (e: "update", id: number, payload: { name: string; fieldType: ContentType["fieldType"]; hasExpiry: boolean; description?: string }): void;
+  (e: "delete", id: number): void;
+}>();
+
+const dialogVisible = ref(false);
+const editing = ref<ContentType | null>(null);
+const formRef = ref<FormInstance>();
+const form = reactive({
+  name: "",
+  fieldType: "text" as ContentType["fieldType"],
+  hasExpiry: false,
+  description: "",
+});
+
+const fieldTypeLabels: Record<ContentType["fieldType"], string> = {
+  text: "文本",
+  url: "链接",
+  image: "图片",
+  date: "日期",
+  number: "数字",
+};
+
+const fieldTypeOptions = Object.entries(fieldTypeLabels).map(([value, label]) => ({
+  value: value as ContentType["fieldType"],
+  label,
+}));
+
+const rules: FormRules = {
+  name: [{ required: true, message: "请输入名称", trigger: "blur" }],
+  fieldType: [{ required: true, message: "请选择字段类型", trigger: "change" }],
+};
+
+const dialogTitle = computed(() => (editing.value ? "编辑内容类型" : "新建内容类型"));
+
+const resetForm = () => {
+  form.name = "";
+  form.fieldType = "text";
+  form.hasExpiry = false;
+  form.description = "";
+};
+
+const openDialog = (contentType?: ContentType) => {
+  dialogVisible.value = true;
+  if (contentType) {
+    editing.value = contentType;
+    form.name = contentType.name;
+    form.fieldType = contentType.fieldType;
+    form.hasExpiry = contentType.hasExpiry;
+    form.description = contentType.description || "";
+  } else {
+    editing.value = null;
+    resetForm();
+  }
+};
+
+const closeDialog = () => {
+  dialogVisible.value = false;
+  editing.value = null;
+};
+
+const handleSubmit = async () => {
+  if (!formRef.value) return;
+  await formRef.value.validate((valid) => {
+    if (!valid) return;
+    const payload = {
+      name: form.name.trim(),
+      fieldType: form.fieldType,
+      hasExpiry: form.hasExpiry,
+      description: form.description.trim() || undefined,
+    };
+    if (editing.value) {
+      emit("update", editing.value.id, payload);
+    } else {
+      emit("create", payload);
+    }
+    closeDialog();
+  });
+};
+
+const handleDelete = (row: ContentType) => {
+  emit("delete", row.id);
+};
+</script>

--- a/src/components/content/ExpiryStatus.vue
+++ b/src/components/content/ExpiryStatus.vue
@@ -1,0 +1,52 @@
+<template>
+  <el-tag :type="tagType" :size="size" class="expiry-status">
+    <el-icon class="mr-1">
+      <Clock v-if="status === 'safe'" />
+      <Warning v-else-if="status === 'warning'" />
+      <Close v-else />
+    </el-icon>
+    {{ expiryText }}
+  </el-tag>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { Clock, Warning, Close } from "@element-plus/icons-vue";
+import { useDateFormat } from "@/composables/useDateFormat";
+
+type TagSize = "large" | "default" | "small";
+
+interface Props {
+  expiryDate: string;
+  size?: TagSize;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: "default" as TagSize,
+});
+
+const { getExpiryStatus, getExpiryText } = useDateFormat();
+
+const status = computed(() => getExpiryStatus(props.expiryDate));
+const expiryText = computed(() => getExpiryText(props.expiryDate));
+
+const tagType = computed(() => {
+  switch (status.value) {
+    case "safe":
+      return "success";
+    case "warning":
+      return "warning";
+    case "danger":
+      return "danger";
+    default:
+      return "info";
+  }
+});
+</script>
+
+<style scoped>
+.expiry-status {
+  display: inline-flex;
+  align-items: center;
+}
+</style>

--- a/src/components/content/TextCommandList.vue
+++ b/src/components/content/TextCommandList.vue
@@ -1,0 +1,68 @@
+<template>
+  <el-card shadow="never" body-class="space-y-3">
+    <template #header>
+      <div class="flex items-center justify-between">
+        <div>
+          <h3 class="text-base font-semibold text-slate-800">文字口令</h3>
+          <p class="text-xs text-slate-500">展示并管理该子项目下的所有文字口令</p>
+        </div>
+        <el-button type="primary" size="small" @click="emit('add')">
+          <el-icon class="mr-1"><Plus /></el-icon>
+          新增口令
+        </el-button>
+      </div>
+    </template>
+
+    <el-empty v-if="!commandList.length" description="暂无文字口令" />
+    <el-timeline v-else>
+      <el-timeline-item
+        v-for="command in commandList"
+        :key="command.id"
+        :timestamp="formatDate(command.updatedAt)"
+        placement="top"
+        type="primary"
+      >
+        <div class="rounded-lg border border-slate-200 bg-white p-3">
+          <div class="flex items-start justify-between">
+            <div>
+              <p class="text-sm font-medium text-slate-800">{{ command.commandText }}</p>
+              <p class="mt-1 text-xs text-slate-500">有效期：{{ command.expiryDays }} 天</p>
+            </div>
+            <ExpiryStatus :expiry-date="command.expiryDate" size="small" />
+          </div>
+          <div class="mt-3 flex justify-end gap-2 text-sm">
+            <el-button type="primary" link size="small" @click="emit('edit', command)">编辑</el-button>
+            <el-popconfirm
+              title="确定删除该口令吗？"
+              confirm-button-text="删除"
+              cancel-button-text="取消"
+              @confirm="emit('delete', command)"
+            >
+              <template #reference>
+                <el-button type="danger" link size="small">删除</el-button>
+              </template>
+            </el-popconfirm>
+          </div>
+        </div>
+      </el-timeline-item>
+    </el-timeline>
+  </el-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import type { TextCommand } from "@/types";
+import { Plus } from "@element-plus/icons-vue";
+import ExpiryStatus from "@/components/content/ExpiryStatus.vue";
+import { useDateFormat } from "@/composables/useDateFormat";
+
+const props = defineProps<{ commands: TextCommand[] }>();
+const emit = defineEmits<{
+  (e: "add"): void;
+  (e: "edit", command: TextCommand): void;
+  (e: "delete", command: TextCommand): void;
+}>();
+
+const { formatDate } = useDateFormat();
+const commandList = computed(() => props.commands ?? []);
+</script>

--- a/src/components/layout/MobileLayout.vue
+++ b/src/components/layout/MobileLayout.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="mobile-layout">
+    <header class="mobile-header">
+      <div class="header-content">
+        <el-button v-if="showBack" type="text" size="large" @click="handleBack">
+          <el-icon><ArrowLeft /></el-icon>
+        </el-button>
+        <h1 class="header-title">{{ title }}</h1>
+        <div class="header-actions">
+          <slot name="actions" />
+        </div>
+      </div>
+    </header>
+
+    <main class="mobile-main">
+      <slot />
+    </main>
+
+    <footer v-if="$slots.footer" class="mobile-footer">
+      <slot name="footer" />
+    </footer>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ArrowLeft } from "@element-plus/icons-vue";
+import { useRouter } from "vue-router";
+
+interface Props {
+  title: string;
+  showBack?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  showBack: true,
+});
+
+const router = useRouter();
+
+const handleBack = () => {
+  router.back();
+};
+</script>
+
+<style scoped>
+.mobile-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background-color: #f5f5f5;
+}
+
+.mobile-header {
+  background: white;
+  border-bottom: 1px solid #e5e5e5;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  height: 56px;
+  gap: 12px;
+}
+
+.header-title {
+  flex: 1;
+  text-align: center;
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.header-actions {
+  min-width: 44px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.mobile-main {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.mobile-footer {
+  background: white;
+  border-top: 1px solid #e5e5e5;
+  padding: 12px 16px;
+}
+</style>

--- a/src/components/project/ProjectCard.vue
+++ b/src/components/project/ProjectCard.vue
@@ -1,0 +1,75 @@
+<template>
+  <el-card class="project-card cursor-pointer transition-shadow hover:shadow-lg" @click="handleClick">
+    <template #header>
+      <div class="flex items-center justify-between">
+        <h3 class="text-lg font-semibold text-slate-800 truncate">{{ project.name }}</h3>
+        <el-dropdown @command="handleCommand" trigger="click" @click.stop>
+          <el-button type="text" size="small">
+            <el-icon><MoreFilled /></el-icon>
+          </el-button>
+          <template #dropdown>
+            <el-dropdown-menu>
+              <el-dropdown-item command="edit">编辑</el-dropdown-item>
+              <el-dropdown-item command="delete" divided>删除</el-dropdown-item>
+            </el-dropdown-menu>
+          </template>
+        </el-dropdown>
+      </div>
+    </template>
+
+    <div class="space-y-3">
+      <p class="line-clamp-2 text-sm text-slate-600">
+        {{ project.description || "暂无描述" }}
+      </p>
+      <div class="flex items-center justify-between text-xs text-slate-500">
+        <span class="flex items-center gap-1">
+          <el-icon><CollectionTag /></el-icon>
+          {{ project.subProjectCount }} 个子项目
+        </span>
+        <span>{{ formatDate(project.updatedAt) }}</span>
+      </div>
+    </div>
+  </el-card>
+</template>
+
+<script setup lang="ts">
+import type { Project } from "@/types";
+import { useDateFormat } from "@/composables/useDateFormat";
+import { CollectionTag, MoreFilled } from "@element-plus/icons-vue";
+
+interface Props {
+  project: Project;
+}
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+  (e: "click", project: Project): void;
+  (e: "edit", project: Project): void;
+  (e: "delete", project: Project): void;
+}>();
+
+const { formatDate } = useDateFormat();
+
+const handleClick = () => {
+  emit("click", props.project);
+};
+
+const handleCommand = (command: string) => {
+  if (command === "edit") {
+    emit("edit", props.project);
+  }
+  if (command === "delete") {
+    emit("delete", props.project);
+  }
+};
+</script>
+
+<style scoped>
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+</style>

--- a/src/components/project/ProjectForm.vue
+++ b/src/components/project/ProjectForm.vue
@@ -1,0 +1,84 @@
+<template>
+  <el-form ref="formRef" :model="form" :rules="rules" label-width="96px" @submit.prevent>
+    <el-form-item label="项目名称" prop="name">
+      <el-input v-model="form.name" placeholder="请输入项目名称" maxlength="60" show-word-limit />
+    </el-form-item>
+    <el-form-item label="项目描述" prop="description">
+      <el-input
+        v-model="form.description"
+        type="textarea"
+        :autosize="{ minRows: 3, maxRows: 6 }"
+        maxlength="200"
+        show-word-limit
+        placeholder="补充项目背景、目标等信息"
+      />
+    </el-form-item>
+    <div class="flex justify-end gap-3 pt-2">
+      <el-button @click="handleCancel">取消</el-button>
+      <el-button type="primary" :loading="submitting" @click="handleSubmit">
+        {{ submitText }}
+      </el-button>
+    </div>
+  </el-form>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, watch } from "vue";
+import type { FormInstance, FormRules } from "element-plus";
+import type { Project } from "@/types";
+
+interface Props {
+  modelValue?: Partial<Project> | null;
+  submitting?: boolean;
+  submitText?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: null,
+  submitting: false,
+  submitText: "提交",
+});
+
+const emit = defineEmits<{
+  (e: "submit", value: { name: string; description?: string | null }): void;
+  (e: "cancel"): void;
+}>();
+
+const formRef = ref<FormInstance>();
+const form = reactive({
+  name: "",
+  description: "",
+});
+
+const rules: FormRules = {
+  name: [
+    { required: true, message: "请输入项目名称", trigger: "blur" },
+    { min: 2, max: 60, message: "长度在 2 到 60 个字符", trigger: "blur" },
+  ],
+  description: [{ max: 200, message: "描述不超过 200 字", trigger: "blur" }],
+};
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (value) {
+      form.name = value.name ?? "";
+      form.description = value.description ?? "";
+    } else {
+      form.name = "";
+      form.description = "";
+    }
+  },
+  { immediate: true }
+);
+
+const handleSubmit = async () => {
+  if (!formRef.value) return;
+  await formRef.value.validate((valid) => {
+    if (!valid) return;
+    emit("submit", { name: form.name.trim(), description: form.description.trim() });
+  });
+};
+
+const handleCancel = () => emit("cancel");
+</script>

--- a/src/components/project/ProjectSearch.vue
+++ b/src/components/project/ProjectSearch.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+    <el-input
+      v-model="model"
+      placeholder="输入项目名称、描述搜索"
+      clearable
+      class="w-full md:w-80"
+      :prefix-icon="Search"
+    />
+    <div class="flex items-center gap-2">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Search } from "@element-plus/icons-vue";
+
+const model = defineModel<string>("modelValue", { default: "" });
+</script>

--- a/src/components/subproject/SubProjectForm.vue
+++ b/src/components/subproject/SubProjectForm.vue
@@ -1,0 +1,98 @@
+<template>
+  <el-form ref="formRef" :model="form" :rules="rules" label-width="100px" @submit.prevent>
+    <el-form-item label="子项目名称" prop="name">
+      <el-input v-model="form.name" placeholder="请输入子项目名称" maxlength="60" show-word-limit />
+    </el-form-item>
+    <el-form-item label="子项目描述" prop="description">
+      <el-input
+        v-model="form.description"
+        type="textarea"
+        :autosize="{ minRows: 3, maxRows: 6 }"
+        maxlength="200"
+        show-word-limit
+        placeholder="子项目的目标、渠道等信息"
+      />
+    </el-form-item>
+    <el-form-item label="排序" prop="sortOrder">
+      <el-input-number v-model="form.sortOrder" :min="1" :max="999" />
+    </el-form-item>
+    <div class="flex justify-end gap-3 pt-2">
+      <el-button @click="handleCancel">取消</el-button>
+      <el-button type="primary" :loading="submitting" @click="handleSubmit">
+        {{ submitText }}
+      </el-button>
+    </div>
+  </el-form>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, watch } from "vue";
+import type { FormInstance, FormRules } from "element-plus";
+import type { SubProject } from "@/types";
+
+interface Props {
+  modelValue?: Partial<SubProject> | null;
+  submitting?: boolean;
+  submitText?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: null,
+  submitting: false,
+  submitText: "提交",
+});
+
+const emit = defineEmits<{
+  (
+    e: "submit",
+    value: { name: string; description?: string; sortOrder: number }
+  ): void;
+  (e: "cancel"): void;
+}>();
+
+const formRef = ref<FormInstance>();
+const form = reactive({
+  name: "",
+  description: "",
+  sortOrder: 1,
+});
+
+const rules: FormRules = {
+  name: [
+    { required: true, message: "请输入子项目名称", trigger: "blur" },
+    { min: 2, max: 60, message: "长度在 2 到 60 个字符", trigger: "blur" },
+  ],
+  description: [{ max: 200, message: "描述不超过 200 字", trigger: "blur" }],
+  sortOrder: [{ required: true, message: "请输入排序", trigger: "change" }],
+};
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (value) {
+      form.name = value.name ?? "";
+      form.description = value.description ?? "";
+      form.sortOrder = value.sortOrder ?? 1;
+    } else {
+      form.name = "";
+      form.description = "";
+      form.sortOrder = 1;
+    }
+  },
+  { immediate: true }
+);
+
+const handleSubmit = async () => {
+  if (!formRef.value) return;
+  await formRef.value.validate((valid) => {
+    if (!valid) return;
+    emit("submit", {
+      name: form.name.trim(),
+      description: form.description.trim(),
+      sortOrder: form.sortOrder,
+    });
+  });
+};
+
+const handleCancel = () => emit("cancel");
+</script>

--- a/src/components/subproject/SubProjectList.vue
+++ b/src/components/subproject/SubProjectList.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="space-y-4">
+    <el-empty v-if="!loading && !subProjects.length" description="暂无子项目，立即创建一个吧" />
+
+    <template v-else>
+      <el-skeleton v-if="loading" animated :count="3">
+        <template #template>
+          <el-card class="mb-4">
+            <el-skeleton-item variant="h1" style="width: 40%;" />
+            <el-skeleton-item variant="text" />
+            <el-skeleton-item variant="text" />
+          </el-card>
+        </template>
+      </el-skeleton>
+
+      <el-collapse v-else accordion>
+        <el-collapse-item v-for="subProject in subProjects" :key="subProject.id" :name="subProject.id">
+          <template #title>
+            <div class="flex flex-1 items-center justify-between pr-4">
+              <div>
+                <div class="flex items-center gap-2">
+                  <span class="text-base font-semibold text-slate-800">{{ subProject.name }}</span>
+                  <el-tag size="small" type="info">排序 {{ subProject.sortOrder }}</el-tag>
+                </div>
+                <p class="mt-1 text-xs text-slate-500">{{ subProject.description || "暂无描述" }}</p>
+              </div>
+              <div class="flex items-center gap-2 text-xs text-slate-500">
+                <span class="flex items-center gap-1">
+                  <el-icon><Document /></el-icon>
+                  内容 {{ subProject.contents.length }}
+                </span>
+                <span class="flex items-center gap-1">
+                  <el-icon><Tickets /></el-icon>
+                  口令 {{ subProject.textCommands.length }}
+                </span>
+              </div>
+            </div>
+          </template>
+
+          <div class="grid gap-4 md:grid-cols-2">
+            <el-card shadow="never" body-class="space-y-3">
+              <div class="flex items-center justify-between">
+                <h4 class="text-sm font-semibold text-slate-700">内容列表</h4>
+                <el-button type="primary" link @click="emit('add-content', subProject)">
+                  <el-icon class="mr-1"><Plus /></el-icon>
+                  新增内容
+                </el-button>
+              </div>
+              <el-empty v-if="!subProject.contents.length" description="暂无内容" :image-size="100" />
+              <div v-else class="space-y-3">
+                <div
+                  v-for="content in subProject.contents"
+                  :key="content.id"
+                  class="rounded-lg border border-slate-200 p-3"
+                >
+                  <div class="flex items-center justify-between text-sm">
+                    <div class="flex items-center gap-2">
+                      <el-tag size="small" effect="dark">{{ content.contentType.name }}</el-tag>
+                      <ExpiryStatus v-if="content.expiryDate" :expiry-date="content.expiryDate" size="small" />
+                    </div>
+                    <el-button type="text" size="small" @click="emit('edit-content', subProject, content)">
+                      编辑
+                    </el-button>
+                  </div>
+                  <p class="mt-2 break-words text-sm text-slate-600">{{ content.contentValue }}</p>
+                </div>
+              </div>
+            </el-card>
+
+            <el-card shadow="never" body-class="space-y-3">
+              <div class="flex items-center justify-between">
+                <h4 class="text-sm font-semibold text-slate-700">文字口令</h4>
+                <el-button type="primary" link @click="emit('add-command', subProject)">
+                  <el-icon class="mr-1"><ChatLineSquare /></el-icon>
+                  新增口令
+                </el-button>
+              </div>
+              <el-empty v-if="!subProject.textCommands.length" description="暂无口令" :image-size="100" />
+              <div v-else class="space-y-3">
+                <div
+                  v-for="command in subProject.textCommands"
+                  :key="command.id"
+                  class="rounded-lg border border-slate-200 p-3"
+                >
+                  <div class="flex items-center justify-between text-sm">
+                    <span class="font-medium text-slate-700">{{ command.commandText }}</span>
+                    <div class="flex items-center gap-2">
+                      <ExpiryStatus :expiry-date="command.expiryDate" size="small" />
+                      <el-dropdown @command="(cmd) => handleCommandAction(cmd, subProject, command)">
+                        <span class="cursor-pointer text-primary-600"><el-icon><MoreFilled /></el-icon></span>
+                        <template #dropdown>
+                          <el-dropdown-menu>
+                            <el-dropdown-item command="edit">编辑</el-dropdown-item>
+                            <el-dropdown-item command="delete" divided>删除</el-dropdown-item>
+                          </el-dropdown-menu>
+                        </template>
+                      </el-dropdown>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </el-card>
+          </div>
+
+          <div class="mt-4 flex justify-end gap-2 border-t border-slate-100 pt-4">
+            <el-button size="small" @click="emit('edit', subProject)">编辑子项目</el-button>
+            <el-button size="small" type="danger" plain @click="emit('delete', subProject)">
+              删除
+            </el-button>
+          </div>
+        </el-collapse-item>
+      </el-collapse>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Document, Tickets, Plus, ChatLineSquare, MoreFilled } from "@element-plus/icons-vue";
+import type { SubProject, SubProjectContent, TextCommand } from "@/types";
+import ExpiryStatus from "@/components/content/ExpiryStatus.vue";
+
+interface Props {
+  subProjects: SubProject[];
+  loading?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  loading: false,
+});
+
+const emit = defineEmits<{
+  (e: "edit", subProject: SubProject): void;
+  (e: "delete", subProject: SubProject): void;
+  (e: "add-content", subProject: SubProject): void;
+  (e: "edit-content", subProject: SubProject, content: SubProjectContent): void;
+  (e: "add-command", subProject: SubProject): void;
+  (e: "edit-command", subProject: SubProject, command: TextCommand): void;
+  (e: "delete-command", subProject: SubProject, command: TextCommand): void;
+}>();
+
+const handleCommandAction = (
+  command: "edit" | "delete",
+  subProject: SubProject,
+  textCommand: TextCommand
+) => {
+  if (command === "edit") emit("edit-command", subProject, textCommand);
+  if (command === "delete") emit("delete-command", subProject, textCommand);
+};
+</script>

--- a/src/components/subproject/SubProjectSort.vue
+++ b/src/components/subproject/SubProjectSort.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="space-y-4">
+    <el-alert type="info" title="拖拽或使用按钮调整排序，排序越小越靠前" show-icon />
+    <el-table :data="internalList" row-key="id" border>
+      <el-table-column type="index" width="60" label="#" />
+      <el-table-column prop="name" label="子项目名称" min-width="220" />
+      <el-table-column prop="description" label="描述" min-width="260">
+        <template #default="{ row }">
+          <span class="text-sm text-slate-600">{{ row.description || "--" }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="操作" width="160">
+        <template #default="{ $index }">
+          <div class="flex items-center gap-2">
+            <el-button size="small" :disabled="$index === 0" @click="moveUp($index)">
+              上移
+            </el-button>
+            <el-button
+              size="small"
+              :disabled="$index === internalList.length - 1"
+              @click="moveDown($index)"
+            >
+              下移
+            </el-button>
+          </div>
+        </template>
+      </el-table-column>
+    </el-table>
+    <div class="flex justify-end gap-3">
+      <el-button @click="emit('cancel')">取消</el-button>
+      <el-button type="primary" :loading="submitting" @click="handleConfirm">保存排序</el-button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import type { SubProject } from "@/types";
+
+interface Props {
+  modelValue: SubProject[];
+  submitting?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  submitting: false,
+});
+
+const emit = defineEmits<{
+  (e: "update", ids: number[]): void;
+  (e: "cancel"): void;
+}>();
+
+const internalList = ref<SubProject[]>([]);
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    internalList.value = value.slice().sort((a, b) => a.sortOrder - b.sortOrder);
+  },
+  { immediate: true }
+);
+
+const moveUp = (index: number) => {
+  if (index === 0) return;
+  const list = internalList.value;
+  [list[index - 1], list[index]] = [list[index], list[index - 1]];
+};
+
+const moveDown = (index: number) => {
+  const list = internalList.value;
+  if (index >= list.length - 1) return;
+  [list[index + 1], list[index]] = [list[index], list[index + 1]];
+};
+
+const handleConfirm = () => {
+  const ids = internalList.value.map((item) => item.id);
+  emit("update", ids);
+};
+</script>

--- a/src/composables/useContents.ts
+++ b/src/composables/useContents.ts
@@ -1,0 +1,21 @@
+import { storeToRefs } from "pinia";
+import { computed } from "vue";
+import { useContentsStore } from "@/stores/contents";
+
+export function useContents(subProjectId?: number) {
+  const contentsStore = useContentsStore();
+  const { contentTypes, loading } = storeToRefs(contentsStore);
+
+  const availableContentTypes = computed(() => contentTypes.value);
+
+  const getSummary = subProjectId
+    ? () => contentsStore.getContentSummary(subProjectId)
+    : undefined;
+
+  return {
+    ...contentsStore,
+    contentTypes: availableContentTypes,
+    loading,
+    getSummary,
+  };
+}

--- a/src/composables/useDateFormat.ts
+++ b/src/composables/useDateFormat.ts
@@ -1,0 +1,37 @@
+import { computed } from "vue";
+import { formatDate, getExpiryStatus, getExpiryText } from "@/utils/date";
+
+export function useDateFormat() {
+  const formatDateTime = (date: string | Date) => formatDate(date, true);
+  const formatDateOnly = (date: string | Date) => formatDate(date, false);
+
+  return {
+    formatDate: formatDateTime,
+    formatDateOnly,
+    getExpiryStatus,
+    getExpiryText,
+  };
+}
+
+export function useRelativeTime(date: string | Date) {
+  return computed(() => {
+    const current = Date.now();
+    const target = new Date(date).getTime();
+    const diff = current - target;
+    const day = 1000 * 60 * 60 * 24;
+    if (diff < day) {
+      const hour = Math.floor(diff / (1000 * 60 * 60));
+      if (hour <= 0) {
+        const minutes = Math.floor(diff / (1000 * 60));
+        return minutes <= 0 ? "刚刚" : `${minutes} 分钟前`;
+      }
+      return `${hour} 小时前`;
+    }
+    const days = Math.floor(diff / day);
+    if (days < 30) return `${days} 天前`;
+    const months = Math.floor(days / 30);
+    if (months < 12) return `${months} 个月前`;
+    const years = Math.floor(months / 12);
+    return `${years} 年前`;
+  });
+}

--- a/src/composables/useProjects.ts
+++ b/src/composables/useProjects.ts
@@ -1,0 +1,25 @@
+import { storeToRefs } from "pinia";
+import { computed } from "vue";
+import { useProjectsStore } from "@/stores/projects";
+import { useSubProjectsStore } from "@/stores/subProjects";
+
+export function useProjects() {
+  const projectsStore = useProjectsStore();
+  const subProjectsStore = useSubProjectsStore();
+  const { filteredProjects, loading, searchQuery, getProjectSummary } = storeToRefs(projectsStore);
+  const { subProjectStats } = storeToRefs(subProjectsStore);
+
+  const projectStats = computed(() => ({
+    totalProjects: getProjectSummary.value.total,
+    lastUpdated: getProjectSummary.value.updatedAt,
+    subProjectStats: subProjectStats.value,
+  }));
+
+  return {
+    ...projectsStore,
+    filteredProjects,
+    loading,
+    searchQuery,
+    projectStats,
+  };
+}

--- a/src/composables/useResponsive.ts
+++ b/src/composables/useResponsive.ts
@@ -1,0 +1,29 @@
+import { ref, onMounted, onUnmounted } from "vue";
+
+export function useResponsive() {
+  const isMobile = ref(false);
+  const isTablet = ref(false);
+  const isDesktop = ref(false);
+
+  const updateBreakpoint = () => {
+    const width = window.innerWidth;
+    isMobile.value = width < 768;
+    isTablet.value = width >= 768 && width < 1024;
+    isDesktop.value = width >= 1024;
+  };
+
+  onMounted(() => {
+    updateBreakpoint();
+    window.addEventListener("resize", updateBreakpoint);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener("resize", updateBreakpoint);
+  });
+
+  return {
+    isMobile,
+    isTablet,
+    isDesktop,
+  };
+}

--- a/src/composables/useSubProjects.ts
+++ b/src/composables/useSubProjects.ts
@@ -1,0 +1,24 @@
+import { storeToRefs } from "pinia";
+import { computed } from "vue";
+import { useSubProjectsStore } from "@/stores/subProjects";
+import { useContentsStore } from "@/stores/contents";
+
+export function useSubProjects(projectId?: number) {
+  const subProjectsStore = useSubProjectsStore();
+  const contentsStore = useContentsStore();
+  const { subProjects, subProjectStats } = storeToRefs(subProjectsStore);
+
+  const subProjectList = computed(() => {
+    if (!projectId) return subProjects.value.filter((item) => item.isActive);
+    return subProjectsStore.getSubProjectsByProjectId(projectId);
+  });
+
+  const getSummary = (subProjectId: number) => contentsStore.getContentSummary(subProjectId);
+
+  return {
+    ...subProjectsStore,
+    subProjects: subProjectList,
+    stats: subProjectStats,
+    getSummary,
+  };
+}

--- a/src/composables/useTouch.ts
+++ b/src/composables/useTouch.ts
@@ -1,0 +1,63 @@
+import { ref, onMounted, onUnmounted, type Ref } from "vue";
+
+export function useTouch(element: Ref<HTMLElement | null>) {
+  const startX = ref(0);
+  const startY = ref(0);
+  const moveX = ref(0);
+  const moveY = ref(0);
+  const isSwiping = ref(false);
+
+  const handleTouchStart = (event: TouchEvent) => {
+    const touch = event.touches[0];
+    startX.value = touch.clientX;
+    startY.value = touch.clientY;
+    isSwiping.value = false;
+  };
+
+  const handleTouchMove = (event: TouchEvent) => {
+    if (!element.value) return;
+    const touch = event.touches[0];
+    moveX.value = touch.clientX - startX.value;
+    moveY.value = touch.clientY - startY.value;
+
+    if (!isSwiping.value) {
+      isSwiping.value = Math.abs(moveX.value) > Math.abs(moveY.value);
+    }
+
+    if (isSwiping.value) {
+      event.preventDefault();
+    }
+  };
+
+  const handleTouchEnd = () => {
+    startX.value = 0;
+    startY.value = 0;
+    moveX.value = 0;
+    moveY.value = 0;
+    isSwiping.value = false;
+  };
+
+  onMounted(() => {
+    const target = element.value;
+    if (!target) return;
+    target.addEventListener("touchstart", handleTouchStart, { passive: false });
+    target.addEventListener("touchmove", handleTouchMove, { passive: false });
+    target.addEventListener("touchend", handleTouchEnd);
+  });
+
+  onUnmounted(() => {
+    const target = element.value;
+    if (!target) return;
+    target.removeEventListener("touchstart", handleTouchStart);
+    target.removeEventListener("touchmove", handleTouchMove);
+    target.removeEventListener("touchend", handleTouchEnd);
+  });
+
+  return {
+    startX,
+    startY,
+    moveX,
+    moveY,
+    isSwiping,
+  };
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,26 @@
+import { createApp } from "vue";
+import { createPinia } from "pinia";
+import ElementPlus from "element-plus";
+import zhCn from "element-plus/dist/locale/zh-cn.mjs";
+import * as ElementPlusIconsVue from "@element-plus/icons-vue";
+
+import App from "./App.vue";
+import router from "./router";
+
+import "element-plus/dist/index.css";
+import "./styles/index.css";
+
+const app = createApp(App);
+const pinia = createPinia();
+
+app.use(pinia);
+app.use(router);
+app.use(ElementPlus, {
+  locale: zhCn,
+});
+
+Object.entries(ElementPlusIconsVue).forEach(([name, component]) => {
+  app.component(name, component);
+});
+
+app.mount("#app");

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,59 @@
+import { createRouter, createWebHistory } from "vue-router";
+import type { RouteRecordRaw } from "vue-router";
+
+const routes: RouteRecordRaw[] = [
+  {
+    path: "/",
+    redirect: "/projects",
+  },
+  {
+    path: "/projects",
+    name: "ProjectList",
+    component: () => import("@/views/ProjectList.vue"),
+    meta: {
+      title: "项目管理",
+      keepAlive: true,
+    },
+  },
+  {
+    path: "/projects/:id",
+    name: "ProjectDetail",
+    component: () => import("@/views/ProjectDetail.vue"),
+    meta: {
+      title: "项目详情",
+    },
+  },
+  {
+    path: "/projects/:projectId/subprojects/:id",
+    name: "SubProjectDetail",
+    component: () => import("@/views/SubProjectDetail.vue"),
+    meta: {
+      title: "子项目管理",
+    },
+  },
+  {
+    path: "/content-types",
+    name: "ContentManagement",
+    component: () => import("@/views/ContentManagement.vue"),
+    meta: {
+      title: "内容类型管理",
+    },
+  },
+];
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+  scrollBehavior() {
+    return { top: 0 };
+  },
+});
+
+router.beforeEach((to, _from, next) => {
+  if (to.meta?.title) {
+    document.title = `${to.meta.title} - CPS推广项目管理`;
+  }
+  next();
+});
+
+export default router;

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -1,0 +1,42 @@
+import { defineStore } from "pinia";
+import { reactive } from "vue";
+import { sampleIdState } from "./sample-data";
+
+interface IdState {
+  project: number;
+  subProject: number;
+  content: number;
+  command: number;
+  contentType: number;
+}
+
+export const useAppStore = defineStore("app", () => {
+  const idState = reactive<IdState>({ ...sampleIdState });
+  const loadingStack = reactive(new Set<string>());
+
+  const nextId = (key: keyof IdState) => {
+    idState[key] += 1;
+    return idState[key];
+  };
+
+  const startLoading = (key: string) => {
+    loadingStack.add(key);
+  };
+
+  const stopLoading = (key: string) => {
+    loadingStack.delete(key);
+  };
+
+  const isLoading = (key?: string) => {
+    if (key) return loadingStack.has(key);
+    return loadingStack.size > 0;
+  };
+
+  return {
+    idState,
+    nextId,
+    startLoading,
+    stopLoading,
+    isLoading,
+  };
+});

--- a/src/stores/contents.ts
+++ b/src/stores/contents.ts
@@ -1,0 +1,151 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import type { ContentType } from "@/types";
+import { sampleContentTypes } from "./sample-data";
+import { useAppStore } from "./app";
+import { useSubProjectsStore } from "./subProjects";
+import { getExpiryStatus } from "@/utils/date";
+
+export const useContentsStore = defineStore("contents", () => {
+  const contentTypes = ref<ContentType[]>([...sampleContentTypes]);
+  const loading = ref(false);
+
+  const fetchContentTypes = async () => {
+    loading.value = true;
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const createContentType = async (
+    payload: Pick<ContentType, "name" | "fieldType" | "hasExpiry" | "description">
+  ) => {
+    const appStore = useAppStore();
+    const id = appStore.nextId("contentType");
+    const contentType: ContentType = {
+      id,
+      name: payload.name,
+      fieldType: payload.fieldType,
+      hasExpiry: payload.hasExpiry,
+      description: payload.description,
+      isSystem: false,
+    };
+    contentTypes.value.push(contentType);
+    return contentType;
+  };
+
+  const updateContentType = async (id: number, payload: Partial<ContentType>) => {
+    const contentType = contentTypes.value.find((item) => item.id === id);
+    if (!contentType) throw new Error("内容类型不存在");
+    Object.assign(contentType, payload);
+    return contentType;
+  };
+
+  const deleteContentType = async (id: number) => {
+    const contentType = contentTypes.value.find((item) => item.id === id);
+    if (!contentType) throw new Error("内容类型不存在");
+    if (contentType.isSystem) {
+      throw new Error("系统内容类型不可删除");
+    }
+    contentTypes.value = contentTypes.value.filter((item) => item.id !== id);
+  };
+
+  const addContent = async (
+    subProjectId: number,
+    payload: {
+      contentTypeId: number;
+      contentValue: string;
+      expiryDays?: number;
+    }
+  ) => {
+    const subProjectsStore = useSubProjectsStore();
+    const contentType = contentTypes.value.find((item) => item.id === payload.contentTypeId);
+    if (!contentType) throw new Error("内容类型不存在");
+    return subProjectsStore.addContentToSubProject(subProjectId, {
+      contentType,
+      contentValue: payload.contentValue,
+      expiryDays: payload.expiryDays,
+    });
+  };
+
+  const updateContent = async (
+    subProjectId: number,
+    contentId: number,
+    payload: {
+      contentTypeId: number;
+      contentValue: string;
+      expiryDays?: number;
+    }
+  ) => {
+    const subProjectsStore = useSubProjectsStore();
+    const contentType = contentTypes.value.find((item) => item.id === payload.contentTypeId);
+    if (!contentType) throw new Error("内容类型不存在");
+    return subProjectsStore.addContentToSubProject(subProjectId, {
+      id: contentId,
+      contentType,
+      contentValue: payload.contentValue,
+      expiryDays: payload.expiryDays,
+    });
+  };
+
+  const removeContent = async (subProjectId: number, contentId: number) => {
+    const subProjectsStore = useSubProjectsStore();
+    return subProjectsStore.removeContentFromSubProject(subProjectId, contentId);
+  };
+
+  const addTextCommand = async (
+    subProjectId: number,
+    payload: { commandText: string; expiryDays: number }
+  ) => {
+    const subProjectsStore = useSubProjectsStore();
+    return subProjectsStore.upsertTextCommand(subProjectId, payload);
+  };
+
+  const updateTextCommand = async (
+    subProjectId: number,
+    commandId: number,
+    payload: { commandText: string; expiryDays: number }
+  ) => {
+    const subProjectsStore = useSubProjectsStore();
+    return subProjectsStore.upsertTextCommand(subProjectId, {
+      id: commandId,
+      ...payload,
+    });
+  };
+
+  const removeTextCommand = async (subProjectId: number, commandId: number) => {
+    const subProjectsStore = useSubProjectsStore();
+    return subProjectsStore.removeTextCommand(subProjectId, commandId);
+  };
+
+  const getContentSummary = (subProjectId: number) => {
+    const subProjectsStore = useSubProjectsStore();
+    const subProject = subProjectsStore.getSubProjectById(subProjectId);
+    if (!subProject) return { total: 0, expiringSoon: 0 };
+    const expiringSoon = subProject.contents.filter((content) =>
+      content.expiryDate ? getExpiryStatus(content.expiryDate) !== "safe" : false
+    ).length;
+    return {
+      total: subProject.contents.length,
+      expiringSoon,
+    };
+  };
+
+  return {
+    contentTypes,
+    loading,
+    fetchContentTypes,
+    createContentType,
+    updateContentType,
+    deleteContentType,
+    addContent,
+    updateContent,
+    removeContent,
+    addTextCommand,
+    updateTextCommand,
+    removeTextCommand,
+    getContentSummary,
+  };
+});

--- a/src/stores/projects.ts
+++ b/src/stores/projects.ts
@@ -1,0 +1,114 @@
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+import type { Project } from "@/types";
+import { useAppStore } from "./app";
+import { sampleProjects, sampleSubProjects } from "./sample-data";
+import { useSubProjectsStore } from "./subProjects";
+import { formatDate } from "@/utils/date";
+
+export const useProjectsStore = defineStore("projects", () => {
+  const projects = ref<Project[]>([...sampleProjects]);
+  const loading = ref(false);
+  const searchQuery = ref("");
+
+  const filteredProjects = computed(() => {
+    if (!searchQuery.value) return projects.value.filter((item) => item.isActive);
+    const query = searchQuery.value.toLowerCase();
+    return projects.value.filter((project) => {
+      if (!project.isActive) return false;
+      return (
+        project.name.toLowerCase().includes(query) ||
+        project.description?.toLowerCase().includes(query)
+      );
+    });
+  });
+
+  const getProjectById = (id: number) =>
+    projects.value.find((project) => project.id === id && project.isActive);
+
+  const fetchProjects = async () => {
+    loading.value = true;
+    try {
+      // simulate network latency
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      // ensure sub project counts are up to date
+      const subProjectsStore = useSubProjectsStore();
+      projects.value = projects.value.map((project) => ({
+        ...project,
+        subProjectCount: subProjectsStore
+          .getSubProjectsByProjectId(project.id)
+          .filter((item) => item.isActive).length,
+      }));
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const createProject = async (projectData: Pick<Project, "name" | "description">) => {
+    const appStore = useAppStore();
+    const subProjectsStore = useSubProjectsStore();
+    const id = appStore.nextId("project");
+    const now = new Date().toISOString();
+    const project: Project = {
+      id,
+      name: projectData.name,
+      description: projectData.description,
+      createdAt: now,
+      updatedAt: now,
+      subProjectCount: 0,
+      isActive: true,
+    };
+    projects.value.unshift(project);
+    await subProjectsStore.ensureSubProjectsForProject(id);
+    return project;
+  };
+
+  const updateProject = async (id: number, payload: Partial<Project>) => {
+    const target = projects.value.find((project) => project.id === id);
+    if (!target) throw new Error("项目不存在");
+    Object.assign(target, payload, {
+      updatedAt: new Date().toISOString(),
+    });
+    return target;
+  };
+
+  const deleteProject = async (id: number) => {
+    const target = projects.value.find((project) => project.id === id);
+    if (!target) throw new Error("项目不存在");
+    target.isActive = false;
+    target.updatedAt = new Date().toISOString();
+    return target;
+  };
+
+  const importSampleData = () => {
+    const subProjectsStore = useSubProjectsStore();
+    subProjectsStore.replaceAll(sampleSubProjects);
+    projects.value = [...sampleProjects];
+  };
+
+  const getProjectSummary = computed(() => {
+    const total = projects.value.filter((item) => item.isActive).length;
+    const updatedAt = projects.value
+      .filter((item) => item.isActive)
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0]
+      ?.updatedAt;
+    return {
+      total,
+      updatedAt: updatedAt ? formatDate(updatedAt) : "",
+    };
+  });
+
+  return {
+    projects,
+    loading,
+    searchQuery,
+    filteredProjects,
+    fetchProjects,
+    createProject,
+    updateProject,
+    deleteProject,
+    getProjectById,
+    importSampleData,
+    getProjectSummary,
+  };
+});

--- a/src/stores/sample-data.ts
+++ b/src/stores/sample-data.ts
@@ -1,0 +1,134 @@
+import { DEFAULT_CONTENT_TYPES } from "@/utils/constants";
+import type {
+  ContentType,
+  Project,
+  SubProject,
+  SubProjectContent,
+  TextCommand,
+} from "@/types";
+import { calculateExpiryDate, getExpiryStatus } from "@/utils/date";
+
+const now = new Date().toISOString();
+
+const sampleContents: SubProjectContent[] = [
+  {
+    id: 1,
+    subProjectId: 1,
+    contentType: DEFAULT_CONTENT_TYPES[0],
+    contentValue: "https://cps.example.com/short/abc123",
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: 2,
+    subProjectId: 1,
+    contentType: DEFAULT_CONTENT_TYPES[2],
+    contentValue: "团购超级优惠",
+    expiryDays: 7,
+    expiryDate: calculateExpiryDate(7),
+    expiryStatus: getExpiryStatus(calculateExpiryDate(7)),
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: 3,
+    subProjectId: 2,
+    contentType: DEFAULT_CONTENT_TYPES[5],
+    contentValue: "https://cdn.example.com/images/product.png",
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
+const sampleCommands: TextCommand[] = [
+  {
+    id: 1,
+    subProjectId: 1,
+    commandText: "复制口令打开淘宝",
+    expiryDays: 5,
+    expiryDate: calculateExpiryDate(5),
+    expiryStatus: getExpiryStatus(calculateExpiryDate(5)),
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: 2,
+    subProjectId: 2,
+    commandText: "京东超值券",
+    expiryDays: 2,
+    expiryDate: calculateExpiryDate(2),
+    expiryStatus: getExpiryStatus(calculateExpiryDate(2)),
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
+export const sampleSubProjects: SubProject[] = [
+  {
+    id: 1,
+    projectId: 1,
+    name: "数码家电",
+    description: "618 主推数码产品",
+    sortOrder: 1,
+    contents: sampleContents.filter((content) => content.subProjectId === 1),
+    textCommands: sampleCommands.filter((command) => command.subProjectId === 1),
+    createdAt: now,
+    updatedAt: now,
+    isActive: true,
+  },
+  {
+    id: 2,
+    projectId: 1,
+    name: "居家百货",
+    description: "热门居家用品",
+    sortOrder: 2,
+    contents: sampleContents.filter((content) => content.subProjectId === 2),
+    textCommands: sampleCommands.filter((command) => command.subProjectId === 2),
+    createdAt: now,
+    updatedAt: now,
+    isActive: true,
+  },
+  {
+    id: 3,
+    projectId: 2,
+    name: "直播爆款",
+    description: "抖音直播热销",
+    sortOrder: 1,
+    contents: [],
+    textCommands: [],
+    createdAt: now,
+    updatedAt: now,
+    isActive: true,
+  },
+];
+
+export const sampleProjects: Project[] = [
+  {
+    id: 1,
+    name: "618 大促项目",
+    description: "618 大促全渠道推广计划",
+    subProjectCount: 2,
+    createdAt: now,
+    updatedAt: now,
+    isActive: true,
+  },
+  {
+    id: 2,
+    name: "抖音内容投放",
+    description: "抖音达人合作推广",
+    subProjectCount: 1,
+    createdAt: now,
+    updatedAt: now,
+    isActive: true,
+  },
+];
+
+export const sampleContentTypes: ContentType[] = [...DEFAULT_CONTENT_TYPES];
+
+export const sampleIdState = {
+  project: sampleProjects.length,
+  subProject: sampleSubProjects.length,
+  content: sampleContents.length,
+  command: sampleCommands.length,
+  contentType: sampleContentTypes.length,
+};

--- a/src/stores/subProjects.ts
+++ b/src/stores/subProjects.ts
@@ -1,0 +1,206 @@
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+import type { SubProject, SubProjectContent, TextCommand } from "@/types";
+import { useAppStore } from "./app";
+import { sampleSubProjects } from "./sample-data";
+import { useProjectsStore } from "./projects";
+import { calculateExpiryDate, getExpiryStatus } from "@/utils/date";
+
+export const useSubProjectsStore = defineStore("subProjects", () => {
+  const subProjects = ref<SubProject[]>([...sampleSubProjects]);
+  const loading = ref(false);
+
+  const getSubProjectsByProjectId = (projectId: number) =>
+    subProjects.value
+      .filter((sub) => sub.projectId === projectId && sub.isActive)
+      .sort((a, b) => a.sortOrder - b.sortOrder);
+
+  const getSubProjectById = (id: number) =>
+    subProjects.value.find((subProject) => subProject.id === id && subProject.isActive);
+
+  const ensureSubProjectsForProject = async (_projectId: number) => {
+    return true;
+  };
+
+  const replaceAll = (data: SubProject[]) => {
+    subProjects.value = [...data];
+  };
+
+  const createSubProject = async (
+    projectId: number,
+    payload: Pick<SubProject, "name" | "description" | "sortOrder">
+  ) => {
+    const appStore = useAppStore();
+    const id = appStore.nextId("subProject");
+    const now = new Date().toISOString();
+    const subProject: SubProject = {
+      id,
+      projectId,
+      name: payload.name,
+      description: payload.description,
+      sortOrder: payload.sortOrder,
+      contents: [],
+      textCommands: [],
+      createdAt: now,
+      updatedAt: now,
+      isActive: true,
+    };
+    subProjects.value.push(subProject);
+    const projectStore = useProjectsStore();
+    const project = projectStore.projects.find((item) => item.id === projectId);
+    if (project) {
+      project.subProjectCount = getSubProjectsByProjectId(projectId).length;
+      project.updatedAt = now;
+    }
+    return subProject;
+  };
+
+  const updateSubProject = async (id: number, payload: Partial<SubProject>) => {
+    const subProject = subProjects.value.find((item) => item.id === id);
+    if (!subProject) throw new Error("子项目不存在");
+    Object.assign(subProject, payload, {
+      updatedAt: new Date().toISOString(),
+    });
+    return subProject;
+  };
+
+  const deleteSubProject = async (id: number) => {
+    const subProject = subProjects.value.find((item) => item.id === id);
+    if (!subProject) throw new Error("子项目不存在");
+    subProject.isActive = false;
+    const projectStore = useProjectsStore();
+    const project = projectStore.projects.find((item) => item.id === subProject.projectId);
+    if (project) {
+      project.subProjectCount = getSubProjectsByProjectId(project.id).length;
+      project.updatedAt = new Date().toISOString();
+    }
+    return subProject;
+  };
+
+  const reorderSubProjects = async (projectId: number, orderedIds: number[]) => {
+    orderedIds.forEach((subProjectId, index) => {
+      const subProject = subProjects.value.find((item) => item.id === subProjectId);
+      if (subProject && subProject.projectId === projectId) {
+        subProject.sortOrder = index + 1;
+      }
+    });
+    return getSubProjectsByProjectId(projectId);
+  };
+
+  const addContentToSubProject = (
+    subProjectId: number,
+    content: Omit<SubProjectContent, "id" | "createdAt" | "updatedAt"> & {
+      id?: number;
+    }
+  ) => {
+    const subProject = subProjects.value.find((item) => item.id === subProjectId);
+    if (!subProject) throw new Error("子项目不存在");
+    const appStore = useAppStore();
+    const now = new Date().toISOString();
+    const id = content.id ?? appStore.nextId("content");
+    const expiryDate =
+      content.expiryDays && content.contentType.hasExpiry
+        ? calculateExpiryDate(content.expiryDays)
+        : content.expiryDate;
+    const expiryStatus = expiryDate ? getExpiryStatus(expiryDate) : undefined;
+    const newContent: SubProjectContent = {
+      id,
+      subProjectId,
+      contentType: content.contentType,
+      contentValue: content.contentValue,
+      expiryDays: content.expiryDays,
+      expiryDate,
+      expiryStatus,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const existingIndex = subProject.contents.findIndex((item) => item.id === id);
+    if (existingIndex >= 0) {
+      subProject.contents.splice(existingIndex, 1, newContent);
+    } else {
+      subProject.contents.push(newContent);
+    }
+    subProject.updatedAt = now;
+    const projectStore = useProjectsStore();
+    const project = projectStore.projects.find((item) => item.id === subProject.projectId);
+    if (project) project.updatedAt = now;
+    return newContent;
+  };
+
+  const removeContentFromSubProject = (subProjectId: number, contentId: number) => {
+    const subProject = subProjects.value.find((item) => item.id === subProjectId);
+    if (!subProject) throw new Error("子项目不存在");
+    subProject.contents = subProject.contents.filter((item) => item.id !== contentId);
+    subProject.updatedAt = new Date().toISOString();
+  };
+
+  const upsertTextCommand = (
+    subProjectId: number,
+    payload: Omit<TextCommand, "id" | "expiryDate" | "expiryStatus" | "createdAt" | "updatedAt"> & {
+      id?: number;
+    }
+  ) => {
+    const subProject = subProjects.value.find((item) => item.id === subProjectId);
+    if (!subProject) throw new Error("子项目不存在");
+    const appStore = useAppStore();
+    const now = new Date().toISOString();
+    const id = payload.id ?? appStore.nextId("command");
+    const expiryDate = calculateExpiryDate(payload.expiryDays);
+    const command: TextCommand = {
+      id,
+      subProjectId,
+      commandText: payload.commandText,
+      expiryDays: payload.expiryDays,
+      expiryDate,
+      expiryStatus: getExpiryStatus(expiryDate),
+      createdAt: now,
+      updatedAt: now,
+    };
+    const existingIndex = subProject.textCommands.findIndex((item) => item.id === id);
+    if (existingIndex >= 0) {
+      subProject.textCommands.splice(existingIndex, 1, command);
+    } else {
+      subProject.textCommands.push(command);
+    }
+    subProject.updatedAt = now;
+    return command;
+  };
+
+  const removeTextCommand = (subProjectId: number, commandId: number) => {
+    const subProject = subProjects.value.find((item) => item.id === subProjectId);
+    if (!subProject) throw new Error("子项目不存在");
+    subProject.textCommands = subProject.textCommands.filter((item) => item.id !== commandId);
+    subProject.updatedAt = new Date().toISOString();
+  };
+
+  const subProjectStats = computed(() => {
+    return subProjects.value.reduce(
+      (acc, subProject) => {
+        if (!subProject.isActive) return acc;
+        acc.total += 1;
+        acc.contentTotal += subProject.contents.length;
+        acc.commandTotal += subProject.textCommands.length;
+        return acc;
+      },
+      { total: 0, contentTotal: 0, commandTotal: 0 }
+    );
+  });
+
+  return {
+    subProjects,
+    loading,
+    getSubProjectsByProjectId,
+    getSubProjectById,
+    ensureSubProjectsForProject,
+    replaceAll,
+    createSubProject,
+    updateSubProject,
+    deleteSubProject,
+    reorderSubProjects,
+    addContentToSubProject,
+    removeContentFromSubProject,
+    upsertTextCommand,
+    removeTextCommand,
+    subProjectStats,
+  };
+});

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,27 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  font-family: "Inter", "PingFang SC", "Microsoft YaHei", sans-serif;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+#app {
+  min-height: 100vh;
+}
+
+.el-button--primary {
+  @apply bg-primary-600 border-primary-600;
+}
+
+.el-button--primary.is-plain {
+  @apply text-primary-600 border-primary-200 bg-primary-50;
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,16 @@
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+  error?: string;
+  code?: number;
+  timestamp: string;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -1,0 +1,33 @@
+export type ContentFieldType = "text" | "url" | "image" | "date" | "number";
+
+export interface ContentType {
+  id: number;
+  name: string;
+  fieldType: ContentFieldType;
+  hasExpiry: boolean;
+  isSystem: boolean;
+  description?: string;
+}
+
+export interface SubProjectContent {
+  id: number;
+  subProjectId: number;
+  contentType: ContentType;
+  contentValue: string;
+  expiryDays?: number;
+  expiryDate?: string;
+  expiryStatus?: "safe" | "warning" | "danger";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TextCommand {
+  id: number;
+  subProjectId: number;
+  commandText: string;
+  expiryDays: number;
+  expiryDate: string;
+  expiryStatus: "safe" | "warning" | "danger";
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from "./project";
+export * from "./content";
+export * from "./api";

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,24 @@
+import type { SubProjectContent, TextCommand } from "./content";
+
+export interface Project {
+  id: number;
+  name: string;
+  description?: string;
+  subProjectCount: number;
+  createdAt: string;
+  updatedAt: string;
+  isActive: boolean;
+}
+
+export interface SubProject {
+  id: number;
+  projectId: number;
+  name: string;
+  description?: string;
+  sortOrder: number;
+  contents: SubProjectContent[];
+  textCommands: TextCommand[];
+  createdAt: string;
+  updatedAt: string;
+  isActive: boolean;
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,62 @@
+import axios from "axios";
+import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
+import { ElMessage } from "element-plus";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "/api";
+
+class ApiClient {
+  private instance: AxiosInstance;
+
+  constructor() {
+    this.instance = axios.create({
+      baseURL: API_BASE_URL,
+      timeout: 15000,
+      withCredentials: true,
+    });
+
+    this.instance.interceptors.request.use((config) => {
+      const token = localStorage.getItem("cps_token");
+      if (token) {
+        config.headers = config.headers || {};
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+      return config;
+    });
+
+    this.instance.interceptors.response.use(
+      (response) => response,
+      (error: AxiosError<{ message?: string }>) => {
+        const message =
+          error.response?.data?.message || error.message || "网络请求失败";
+        ElMessage.error(message);
+        return Promise.reject(error);
+      }
+    );
+  }
+
+  get<T>(url: string, config?: AxiosRequestConfig) {
+    return this.instance.get<T>(url, config);
+  }
+
+  post<T>(url: string, data?: unknown, config?: AxiosRequestConfig) {
+    return this.instance.post<T>(url, data, config);
+  }
+
+  put<T>(url: string, data?: unknown, config?: AxiosRequestConfig) {
+    return this.instance.put<T>(url, data, config);
+  }
+
+  patch<T>(url: string, data?: unknown, config?: AxiosRequestConfig) {
+    return this.instance.patch<T>(url, data, config);
+  }
+
+  delete<T>(url: string, config?: AxiosRequestConfig) {
+    return this.instance.delete<T>(url, config);
+  }
+}
+
+export const api = new ApiClient();
+
+export function unwrap<T>(response: AxiosResponse<T>) {
+  return response.data;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,49 @@
+import type { ContentType } from "@/types";
+
+export const DEFAULT_CONTENT_TYPES: ContentType[] = [
+  {
+    id: 1,
+    name: "短链接",
+    fieldType: "url",
+    hasExpiry: false,
+    isSystem: true,
+    description: "跳转使用的短链接",
+  },
+  {
+    id: 2,
+    name: "长链接",
+    fieldType: "url",
+    hasExpiry: false,
+    isSystem: true,
+    description: "原始链接地址",
+  },
+  {
+    id: 3,
+    name: "团口令",
+    fieldType: "text",
+    hasExpiry: true,
+    isSystem: true,
+    description: "用于活动的团口令",
+  },
+  {
+    id: 4,
+    name: "唤起协议",
+    fieldType: "text",
+    hasExpiry: false,
+    isSystem: true,
+  },
+  {
+    id: 5,
+    name: "H5 图片",
+    fieldType: "image",
+    hasExpiry: false,
+    isSystem: true,
+  },
+  {
+    id: 6,
+    name: "小程序图片",
+    fieldType: "image",
+    hasExpiry: false,
+    isSystem: true,
+  },
+];

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,43 @@
+export function formatDate(date: string | Date, withTime = true) {
+  const dateObj = typeof date === "string" ? new Date(date) : date;
+  if (Number.isNaN(dateObj.getTime())) return "--";
+  return new Intl.DateTimeFormat("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: withTime ? "2-digit" : undefined,
+    minute: withTime ? "2-digit" : undefined,
+  }).format(dateObj);
+}
+
+export function calculateExpiryDate(days: number) {
+  const now = new Date();
+  now.setDate(now.getDate() + days);
+  return now.toISOString();
+}
+
+export function getExpiryStatus(expiryDate?: string) {
+  if (!expiryDate) return "safe";
+  const now = new Date();
+  const target = new Date(expiryDate);
+  const diff = target.getTime() - now.getTime();
+  const days = diff / (1000 * 60 * 60 * 24);
+
+  if (Number.isNaN(days)) return "safe";
+  if (days < 0) return "danger";
+  if (days <= 3) return "danger";
+  if (days <= 7) return "warning";
+  return "safe";
+}
+
+export function getExpiryText(expiryDate?: string) {
+  if (!expiryDate) return "长期有效";
+  const target = new Date(expiryDate);
+  const now = new Date();
+  const diff = target.getTime() - now.getTime();
+  const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+  if (Number.isNaN(days)) return "--";
+  if (days < 0) return `已过期 ${Math.abs(days)} 天`;
+  if (days === 0) return "今日到期";
+  return `剩余 ${days} 天`;
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,16 @@
+export function isValidUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return Boolean(url.protocol && url.host);
+  } catch (error) {
+    return false;
+  }
+}
+
+export function isPositiveInteger(value: unknown) {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value > 0;
+  }
+  const num = Number(value);
+  return Number.isInteger(num) && num > 0;
+}

--- a/src/views/ContentManagement.vue
+++ b/src/views/ContentManagement.vue
@@ -1,0 +1,284 @@
+<template>
+  <section class="space-y-6">
+    <el-card shadow="never" body-class="space-y-4">
+      <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-2xl font-semibold text-slate-900">内容类型管理</h2>
+          <p class="text-sm text-slate-500">配置推广素材的字段类型与有效期规则，支持灵活扩展</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+          <span class="flex items-center gap-1">
+            <el-icon><CollectionTag /></el-icon>
+            子项目 {{ subProjectStats.total }}
+          </span>
+          <span class="flex items-center gap-1">
+            <el-icon><Document /></el-icon>
+            内容条目 {{ subProjectStats.contentTotal }}
+          </span>
+          <span class="flex items-center gap-1">
+            <el-icon><Tickets /></el-icon>
+            文字口令 {{ subProjectStats.commandTotal }}
+          </span>
+        </div>
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+          <p class="text-xs text-slate-500">内容类型总数</p>
+          <p class="mt-1 text-2xl font-semibold text-slate-900">{{ totalContentTypes }}</p>
+        </div>
+        <div class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+          <p class="text-xs text-slate-500">系统内置类型</p>
+          <p class="mt-1 text-2xl font-semibold text-slate-900">{{ systemTypeCount }}</p>
+        </div>
+        <div class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+          <p class="text-xs text-slate-500">自定义类型</p>
+          <p class="mt-1 text-2xl font-semibold text-slate-900">{{ customTypeCount }}</p>
+        </div>
+        <div class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+          <p class="text-xs text-slate-500">需要有效期的类型</p>
+          <p class="mt-1 text-2xl font-semibold text-slate-900">{{ expiryTypeCount }}</p>
+        </div>
+      </div>
+    </el-card>
+
+    <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <el-card shadow="never" body-class="space-y-3">
+        <template #header>
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-semibold text-slate-700">内容有效期状态</span>
+            <el-tag size="small" type="warning">即将过期 {{ expirySummary.warning }}</el-tag>
+          </div>
+        </template>
+        <div class="space-y-2 text-sm text-slate-600">
+          <div class="flex items-center justify-between rounded border border-slate-200 px-3 py-2">
+            <span class="flex items-center gap-2"><el-tag size="small" type="success">安全</el-tag></span>
+            <span>{{ expirySummary.safe }}</span>
+          </div>
+          <div class="flex items-center justify-between rounded border border-slate-200 px-3 py-2">
+            <span class="flex items-center gap-2"><el-tag size="small" type="warning">警告</el-tag></span>
+            <span>{{ expirySummary.warning }}</span>
+          </div>
+          <div class="flex items-center justify-between rounded border border-slate-200 px-3 py-2">
+            <span class="flex items-center gap-2"><el-tag size="small" type="danger">过期</el-tag></span>
+            <span>{{ expirySummary.danger }}</span>
+          </div>
+        </div>
+      </el-card>
+
+      <el-card shadow="never" body-class="space-y-3">
+        <template #header>
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-semibold text-slate-700">到期内容提醒</span>
+            <el-tag size="small" type="danger">{{ expiringContentCount }}</el-tag>
+          </div>
+        </template>
+        <el-empty v-if="!expiringContentCount" description="暂无即将到期的内容" />
+        <ul v-else class="space-y-3 text-sm text-slate-600">
+          <li v-for="item in expiringSoonList" :key="item.id" class="rounded-lg border border-slate-200 p-3">
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-2">
+                <el-tag size="small">{{ item.contentTypeName }}</el-tag>
+                <span class="text-xs text-slate-500">{{ item.subProjectName }}</span>
+              </div>
+              <ExpiryStatus :expiry-date="item.expiryDate" size="small" />
+            </div>
+            <p class="mt-2 break-words text-slate-700">{{ item.contentValue }}</p>
+            <p class="mt-1 text-xs text-slate-400">到期日 {{ formatDateOnly(item.expiryDate) }} · {{ item.expiryText }}</p>
+          </li>
+        </ul>
+      </el-card>
+
+      <el-card shadow="never" body-class="space-y-3">
+        <template #header>
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-semibold text-slate-700">口令到期提醒</span>
+            <el-tag size="small" type="danger">{{ expiringCommandCount }}</el-tag>
+          </div>
+        </template>
+        <el-empty v-if="!expiringCommandCount" description="暂无即将到期的口令" />
+        <ul v-else class="space-y-3 text-sm text-slate-600">
+          <li v-for="command in commandExpiringList" :key="command.id" class="rounded-lg border border-slate-200 p-3">
+            <div class="flex items-center justify-between">
+              <span class="font-medium text-slate-800">{{ command.commandText }}</span>
+              <ExpiryStatus :expiry-date="command.expiryDate" size="small" />
+            </div>
+            <p class="mt-1 text-xs text-slate-500">{{ command.subProjectName }} · {{ command.expiryText }}</p>
+          </li>
+        </ul>
+      </el-card>
+    </div>
+
+    <div class="grid gap-4 lg:grid-cols-3">
+      <div class="lg:col-span-2">
+        <LoadingSpinner v-if="loading" text="内容类型加载中..." />
+        <ContentTypeManager
+          v-else
+          :content-types="contentTypes"
+          :submitting="submitting"
+          @create="handleCreateType"
+          @update="handleUpdateType"
+          @delete="handleDeleteType"
+        />
+      </div>
+      <div class="space-y-4">
+        <el-card shadow="never" body-class="space-y-2">
+          <h3 class="text-sm font-semibold text-slate-700">操作提示</h3>
+          <ul class="list-disc space-y-1 pl-5 text-xs text-slate-500">
+            <li>系统内置类型不可删除，可编辑描述与时效设置</li>
+            <li>自定义类型可随时调整字段类型以适配新场景</li>
+            <li>时效内容会自动计算到期状态并在此提醒</li>
+          </ul>
+        </el-card>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { ElMessage } from "element-plus";
+import { CollectionTag, Document, Tickets } from "@element-plus/icons-vue";
+import ContentTypeManager from "@/components/content/ContentTypeManager.vue";
+import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
+import ExpiryStatus from "@/components/content/ExpiryStatus.vue";
+import { useContents } from "@/composables/useContents";
+import { useSubProjects } from "@/composables/useSubProjects";
+import { useDateFormat } from "@/composables/useDateFormat";
+import type { ContentType } from "@/types";
+
+type ExpirySummary = {
+  safe: number;
+  warning: number;
+  danger: number;
+};
+
+const { contentTypes, loading, fetchContentTypes, createContentType, updateContentType, deleteContentType } = useContents();
+const { subProjects, stats: subProjectStats } = useSubProjects();
+const { formatDateOnly, getExpiryStatus, getExpiryText } = useDateFormat();
+
+const submitting = ref(false);
+
+const totalContentTypes = computed(() => contentTypes.value.length);
+const systemTypeCount = computed(() => contentTypes.value.filter((type) => type.isSystem).length);
+const customTypeCount = computed(() => totalContentTypes.value - systemTypeCount.value);
+const expiryTypeCount = computed(() => contentTypes.value.filter((type) => type.hasExpiry).length);
+
+const allContents = computed(() =>
+  subProjects.value.flatMap((subProject) =>
+    subProject.contents.map((content) => ({
+      ...content,
+      subProjectName: subProject.name,
+    }))
+  )
+);
+
+const allCommands = computed(() =>
+  subProjects.value.flatMap((subProject) =>
+    subProject.textCommands.map((command) => ({
+      ...command,
+      subProjectName: subProject.name,
+    }))
+  )
+);
+
+const expirySummary = computed<ExpirySummary>(() => {
+  return allContents.value.reduce<ExpirySummary>(
+    (acc, content) => {
+      if (!content.expiryDate) {
+        acc.safe += 1;
+        return acc;
+      }
+      const status = content.expiryStatus ?? getExpiryStatus(content.expiryDate);
+      acc[status] += 1;
+      return acc;
+    },
+    { safe: 0, warning: 0, danger: 0 }
+  );
+});
+
+const expiringSoonList = computed(() =>
+  allContents.value
+    .filter((content) => content.expiryDate)
+    .map((content) => ({
+      id: content.id,
+      contentTypeName: content.contentType.name,
+      contentValue: content.contentValue,
+      subProjectName: content.subProjectName,
+      expiryDate: content.expiryDate!,
+      status: content.expiryStatus ?? getExpiryStatus(content.expiryDate!),
+      expiryText: getExpiryText(content.expiryDate!),
+    }))
+    .filter((item) => item.status !== "safe")
+    .sort((a, b) => new Date(a.expiryDate).getTime() - new Date(b.expiryDate).getTime())
+    .slice(0, 5)
+);
+
+const commandExpiringList = computed(() =>
+  allCommands.value
+    .map((command) => ({
+      ...command,
+      status: command.expiryStatus ?? getExpiryStatus(command.expiryDate),
+      expiryText: getExpiryText(command.expiryDate),
+    }))
+    .filter((command) => command.status !== "safe")
+    .sort((a, b) => new Date(a.expiryDate).getTime() - new Date(b.expiryDate).getTime())
+    .slice(0, 5)
+);
+
+const expiringContentCount = computed(() => expiringSoonList.value.length);
+const expiringCommandCount = computed(() => commandExpiringList.value.length);
+
+const handleCreateType = async (payload: {
+  name: string;
+  fieldType: ContentType["fieldType"];
+  hasExpiry: boolean;
+  description?: string;
+}) => {
+  submitting.value = true;
+  try {
+    await createContentType(payload);
+    ElMessage.success("内容类型创建成功");
+  } catch (error) {
+    ElMessage.error("创建内容类型失败");
+  } finally {
+    submitting.value = false;
+  }
+};
+
+const handleUpdateType = async (
+  id: number,
+  payload: {
+    name: string;
+    fieldType: ContentType["fieldType"];
+    hasExpiry: boolean;
+    description?: string;
+  }
+) => {
+  submitting.value = true;
+  try {
+    await updateContentType(id, payload);
+    ElMessage.success("内容类型更新成功");
+  } catch (error) {
+    ElMessage.error("更新内容类型失败");
+  } finally {
+    submitting.value = false;
+  }
+};
+
+const handleDeleteType = async (id: number) => {
+  submitting.value = true;
+  try {
+    await deleteContentType(id);
+    ElMessage.success("内容类型已删除");
+  } catch (error) {
+    ElMessage.error(error instanceof Error ? error.message : "删除内容类型失败");
+  } finally {
+    submitting.value = false;
+  }
+};
+
+onMounted(() => {
+  fetchContentTypes();
+});
+</script>

--- a/src/views/ProjectDetail.vue
+++ b/src/views/ProjectDetail.vue
@@ -1,0 +1,423 @@
+<template>
+  <section v-if="project" class="space-y-6">
+    <el-page-header @back="router.back">
+      <template #content>
+        <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-2xl font-semibold text-slate-900">{{ project.name }}</h2>
+            <p class="text-sm text-slate-500">{{ project.description || "暂无描述" }}</p>
+          </div>
+          <div class="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+            <span class="flex items-center gap-1">
+              <el-icon><Timer /></el-icon>
+              更新于 {{ formatDate(project.updatedAt) }}
+            </span>
+            <span class="flex items-center gap-1">
+              <el-icon><CollectionTag /></el-icon>
+              子项目 {{ subProjects.length }}
+            </span>
+            <span class="flex items-center gap-1">
+              <el-icon><Tickets /></el-icon>
+              文字口令 {{ commandTotal }}
+            </span>
+          </div>
+        </div>
+      </template>
+    </el-page-header>
+
+    <el-card shadow="never" body-class="flex flex-wrap gap-3">
+      <el-button type="primary" @click="openSubProjectDialog()">
+        <el-icon class="mr-1"><Plus /></el-icon>
+        新建子项目
+      </el-button>
+      <el-button type="primary" plain @click="openSortDialog" :disabled="!subProjects.length">
+        <el-icon class="mr-1"><Rank /></el-icon>
+        调整排序
+      </el-button>
+      <el-button type="primary" plain @click="openContentTypePage">
+        <el-icon class="mr-1"><Setting /></el-icon>
+        内容类型配置
+      </el-button>
+    </el-card>
+
+    <SubProjectList
+      :sub-projects="subProjects"
+      :loading="subProjectLoading"
+      @edit="openSubProjectDialog"
+      @delete="confirmDeleteSubProject"
+      @add-content="openContentDialog"
+      @edit-content="(sub, content) => openContentDialog(sub, content)"
+      @add-command="openCommandDialog"
+      @edit-command="(sub, command) => openCommandDialog(sub, command)"
+      @delete-command="confirmDeleteCommand"
+    />
+  </section>
+  <el-empty v-else description="项目不存在或已被删除">
+    <el-button type="primary" @click="router.push('/projects')">返回项目列表</el-button>
+  </el-empty>
+
+  <el-dialog :title="subProjectDialogTitle" :model-value="subProjectDialogVisible" width="520px" @close="closeSubProjectDialog">
+    <SubProjectForm
+      :model-value="editingSubProject"
+      :submit-text="editingSubProject ? '保存修改' : '创建子项目'"
+      :submitting="submitting"
+      @submit="handleSubProjectSubmit"
+      @cancel="closeSubProjectDialog"
+    />
+  </el-dialog>
+
+  <el-dialog :title="contentDialogTitle" :model-value="contentDialogVisible" width="560px" @close="closeContentDialog">
+    <ContentEditor
+      v-if="contentDialogVisible"
+      :content-types="contentTypes"
+      :model-value="editingContent"
+      :submit-text="editingContent ? '保存内容' : '新增内容'"
+      :submitting="submitting"
+      @submit="handleContentSubmit"
+      @cancel="closeContentDialog"
+    />
+  </el-dialog>
+
+  <el-dialog title="文字口令" :model-value="commandDialogVisible" width="520px" @close="closeCommandDialog">
+    <el-form ref="commandFormRef" :model="commandForm" :rules="commandRules" label-width="100px">
+      <el-form-item label="口令内容" prop="commandText">
+        <el-input v-model="commandForm.commandText" type="textarea" :autosize="{ minRows: 3, maxRows: 5 }" />
+      </el-form-item>
+      <el-form-item label="有效天数" prop="expiryDays">
+        <el-input-number v-model="commandForm.expiryDays" :min="1" :max="180" />
+      </el-form-item>
+    </el-form>
+    <template #footer>
+      <div class="flex justify-end gap-3">
+        <el-button @click="closeCommandDialog">取消</el-button>
+        <el-button type="primary" :loading="submitting" @click="handleCommandSubmit">
+          {{ editingCommand ? "保存口令" : "新增口令" }}
+        </el-button>
+      </div>
+    </template>
+  </el-dialog>
+
+  <el-dialog title="调整子项目排序" :model-value="sortDialogVisible" width="640px" @close="closeSortDialog">
+    <SubProjectSort :model-value="subProjects" :submitting="submitting" @update="handleSortUpdate" @cancel="closeSortDialog" />
+  </el-dialog>
+
+  <ConfirmDialog
+    :visible="deleteSubProjectDialogVisible"
+    title="删除子项目"
+    description="删除后该子项目及内容将被隐藏，确认继续？"
+    confirm-text="确认删除"
+    :loading="submitting"
+    @confirm="handleSubProjectDelete"
+    @cancel="deleteSubProjectDialogVisible = false"
+  />
+
+  <ConfirmDialog
+    :visible="deleteCommandDialogVisible"
+    title="删除文字口令"
+    description="确认删除该文字口令吗？"
+    confirm-text="确认删除"
+    :loading="submitting"
+    @confirm="handleCommandDelete"
+    @cancel="deleteCommandDialogVisible = false"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from "vue";
+import { storeToRefs } from "pinia";
+import { useRoute, useRouter } from "vue-router";
+import { ElMessage } from "element-plus";
+import type { FormInstance, FormRules } from "element-plus";
+import {
+  Timer,
+  CollectionTag,
+  Tickets,
+  Plus,
+  Rank,
+  Setting,
+} from "@element-plus/icons-vue";
+import { useDateFormat } from "@/composables/useDateFormat";
+import { useProjectsStore } from "@/stores/projects";
+import { useSubProjectsStore } from "@/stores/subProjects";
+import { useContentsStore } from "@/stores/contents";
+import SubProjectList from "@/components/subproject/SubProjectList.vue";
+import SubProjectForm from "@/components/subproject/SubProjectForm.vue";
+import SubProjectSort from "@/components/subproject/SubProjectSort.vue";
+import ContentEditor from "@/components/content/ContentEditor.vue";
+import ConfirmDialog from "@/components/common/ConfirmDialog.vue";
+import type { ContentType, SubProject, SubProjectContent, TextCommand } from "@/types";
+
+const route = useRoute();
+const router = useRouter();
+const { formatDate } = useDateFormat();
+
+const projectsStore = useProjectsStore();
+const subProjectsStore = useSubProjectsStore();
+const contentsStore = useContentsStore();
+const { contentTypes } = storeToRefs(contentsStore);
+
+const projectId = Number(route.params.id);
+const project = computed(() => projectsStore.getProjectById(projectId));
+const subProjects = computed(() => subProjectsStore.getSubProjectsByProjectId(projectId));
+const commandTotal = computed(() =>
+  subProjects.value.reduce((total, sub) => total + sub.textCommands.length, 0)
+);
+const subProjectLoading = ref(false);
+
+const dialogVisibleStates = reactive({
+  subProject: false,
+  content: false,
+  command: false,
+  sort: false,
+  deleteSubProject: false,
+  deleteCommand: false,
+});
+
+const submitting = ref(false);
+const editingSubProject = ref<SubProject | null>(null);
+const deletingSubProject = ref<SubProject | null>(null);
+const editingContent = ref<SubProjectContent | null>(null);
+const targetSubProject = ref<SubProject | null>(null);
+const editingCommand = ref<TextCommand | null>(null);
+const deletingCommand = ref<{ subProject: SubProject; command: TextCommand } | null>(null);
+
+const commandFormRef = ref<FormInstance>();
+const commandForm = reactive({
+  commandText: "",
+  expiryDays: 7,
+});
+
+const commandRules: FormRules = {
+  commandText: [{ required: true, message: "请输入口令内容", trigger: "blur" }],
+  expiryDays: [{ required: true, message: "请输入有效天数", trigger: "change" }],
+};
+
+const subProjectDialogVisible = computed({
+  get: () => dialogVisibleStates.subProject,
+  set: (value: boolean) => (dialogVisibleStates.subProject = value),
+});
+const contentDialogVisible = computed({
+  get: () => dialogVisibleStates.content,
+  set: (value: boolean) => (dialogVisibleStates.content = value),
+});
+const commandDialogVisible = computed({
+  get: () => dialogVisibleStates.command,
+  set: (value: boolean) => (dialogVisibleStates.command = value),
+});
+const sortDialogVisible = computed({
+  get: () => dialogVisibleStates.sort,
+  set: (value: boolean) => (dialogVisibleStates.sort = value),
+});
+const deleteSubProjectDialogVisible = computed({
+  get: () => dialogVisibleStates.deleteSubProject,
+  set: (value: boolean) => (dialogVisibleStates.deleteSubProject = value),
+});
+const deleteCommandDialogVisible = computed({
+  get: () => dialogVisibleStates.deleteCommand,
+  set: (value: boolean) => (dialogVisibleStates.deleteCommand = value),
+});
+
+const subProjectDialogTitle = computed(() =>
+  editingSubProject.value ? "编辑子项目" : "新建子项目"
+);
+
+const contentDialogTitle = computed(() =>
+  `${editingContent.value ? "编辑" : "新增"}内容`
+);
+
+const fetchDetail = async () => {
+  if (!project.value) {
+    await projectsStore.fetchProjects();
+  }
+  subProjectLoading.value = true;
+  try {
+    await Promise.all([
+      subProjectsStore.ensureSubProjectsForProject(projectId),
+      contentsStore.fetchContentTypes(),
+    ]);
+  } finally {
+    subProjectLoading.value = false;
+  }
+};
+
+const openSubProjectDialog = (subProject?: SubProject) => {
+  editingSubProject.value = subProject ?? null;
+  subProjectDialogVisible.value = true;
+};
+
+const closeSubProjectDialog = () => {
+  subProjectDialogVisible.value = false;
+  editingSubProject.value = null;
+};
+
+const handleSubProjectSubmit = async (payload: {
+  name: string;
+  description?: string;
+  sortOrder: number;
+}) => {
+  submitting.value = true;
+  try {
+    if (editingSubProject.value) {
+      await subProjectsStore.updateSubProject(editingSubProject.value.id, payload);
+      ElMessage.success("子项目更新成功");
+    } else {
+      await subProjectsStore.createSubProject(projectId, payload);
+      ElMessage.success("子项目创建成功");
+    }
+    closeSubProjectDialog();
+  } catch (error) {
+    ElMessage.error("子项目操作失败");
+  } finally {
+    submitting.value = false;
+  }
+};
+
+const confirmDeleteSubProject = (subProject: SubProject) => {
+  deletingSubProject.value = subProject;
+  deleteSubProjectDialogVisible.value = true;
+};
+
+const handleSubProjectDelete = async () => {
+  if (!deletingSubProject.value) return;
+  submitting.value = true;
+  try {
+    await subProjectsStore.deleteSubProject(deletingSubProject.value.id);
+    ElMessage.success("子项目已删除");
+  } catch (error) {
+    ElMessage.error("删除子项目失败");
+  } finally {
+    submitting.value = false;
+    deleteSubProjectDialogVisible.value = false;
+    deletingSubProject.value = null;
+  }
+};
+
+const openContentDialog = (subProject: SubProject, content?: SubProjectContent) => {
+  targetSubProject.value = subProject;
+  editingContent.value = content ?? null;
+  contentDialogVisible.value = true;
+};
+
+const closeContentDialog = () => {
+  contentDialogVisible.value = false;
+  targetSubProject.value = null;
+  editingContent.value = null;
+};
+
+const handleContentSubmit = async (payload: {
+  contentTypeId: number;
+  contentValue: string;
+  expiryDays?: number;
+}) => {
+  if (!targetSubProject.value) return;
+  submitting.value = true;
+  try {
+    if (editingContent.value) {
+      await contentsStore.updateContent(targetSubProject.value.id, editingContent.value.id, payload);
+      ElMessage.success("内容更新成功");
+    } else {
+      await contentsStore.addContent(targetSubProject.value.id, payload);
+      ElMessage.success("内容新增成功");
+    }
+    closeContentDialog();
+  } catch (error) {
+    ElMessage.error("内容操作失败");
+  } finally {
+    submitting.value = false;
+  }
+};
+
+const openCommandDialog = (subProject: SubProject, command?: TextCommand) => {
+  targetSubProject.value = subProject;
+  editingCommand.value = command ?? null;
+  commandForm.commandText = command?.commandText ?? "";
+  commandForm.expiryDays = command?.expiryDays ?? 7;
+  commandDialogVisible.value = true;
+};
+
+const closeCommandDialog = () => {
+  commandDialogVisible.value = false;
+  targetSubProject.value = null;
+  editingCommand.value = null;
+  commandForm.commandText = "";
+  commandForm.expiryDays = 7;
+};
+
+const handleCommandSubmit = async () => {
+  if (!commandFormRef.value || !targetSubProject.value) return;
+  await commandFormRef.value.validate(async (valid) => {
+    if (!valid) return;
+    submitting.value = true;
+    try {
+      if (editingCommand.value) {
+        await contentsStore.updateTextCommand(targetSubProject.value.id, editingCommand.value.id, {
+          commandText: commandForm.commandText,
+          expiryDays: commandForm.expiryDays,
+        });
+        ElMessage.success("口令更新成功");
+      } else {
+        await contentsStore.addTextCommand(targetSubProject.value.id, {
+          commandText: commandForm.commandText,
+          expiryDays: commandForm.expiryDays,
+        });
+        ElMessage.success("口令新增成功");
+      }
+      closeCommandDialog();
+    } catch (error) {
+      ElMessage.error("口令操作失败");
+    } finally {
+      submitting.value = false;
+    }
+  });
+};
+
+const confirmDeleteCommand = (subProject: SubProject, command: TextCommand) => {
+  deletingCommand.value = { subProject, command };
+  deleteCommandDialogVisible.value = true;
+};
+
+const handleCommandDelete = async () => {
+  if (!deletingCommand.value) return;
+  submitting.value = true;
+  try {
+    await contentsStore.removeTextCommand(
+      deletingCommand.value.subProject.id,
+      deletingCommand.value.command.id
+    );
+    ElMessage.success("口令已删除");
+  } catch (error) {
+    ElMessage.error("删除口令失败");
+  } finally {
+    submitting.value = false;
+    deleteCommandDialogVisible.value = false;
+    deletingCommand.value = null;
+  }
+};
+
+const openSortDialog = () => {
+  sortDialogVisible.value = true;
+};
+
+const closeSortDialog = () => {
+  sortDialogVisible.value = false;
+};
+
+const handleSortUpdate = async (ids: number[]) => {
+  submitting.value = true;
+  try {
+    await subProjectsStore.reorderSubProjects(projectId, ids);
+    ElMessage.success("排序已更新");
+    closeSortDialog();
+  } catch (error) {
+    ElMessage.error("更新排序失败");
+  } finally {
+    submitting.value = false;
+  }
+};
+
+const openContentTypePage = () => {
+  router.push({ name: "ContentManagement" });
+};
+
+onMounted(fetchDetail);
+</script>

--- a/src/views/ProjectList.vue
+++ b/src/views/ProjectList.vue
@@ -1,0 +1,151 @@
+<template>
+  <section class="space-y-6">
+    <el-card shadow="never" body-class="space-y-4">
+      <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-2xl font-semibold text-slate-900">项目管理</h2>
+          <p class="text-sm text-slate-500">集中管理所有推广项目，快速进入子项目及内容配置</p>
+        </div>
+        <div class="flex items-center gap-2 text-xs text-slate-500">
+          <span class="flex items-center gap-1">
+            <el-icon><TrendCharts /></el-icon>
+            子项目总数：{{ projectStats.subProjectStats.total }}
+          </span>
+          <span class="flex items-center gap-1">
+            <el-icon><Tickets /></el-icon>
+            文字口令：{{ projectStats.subProjectStats.commandTotal }}
+          </span>
+        </div>
+      </div>
+
+      <ProjectSearch v-model="searchQuery">
+        <el-button type="primary" @click="openCreateDialog">
+          <el-icon class="mr-1"><Plus /></el-icon>
+          新建项目
+        </el-button>
+      </ProjectSearch>
+    </el-card>
+
+    <LoadingSpinner v-if="loading" text="项目数据加载中..." />
+
+    <div v-else class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <ProjectCard
+        v-for="project in filteredProjects"
+        :key="project.id"
+        :project="project"
+        @click="goProjectDetail(project.id)"
+        @edit="openEditDialog"
+        @delete="confirmDelete"
+      />
+    </div>
+
+    <el-empty v-if="!loading && !filteredProjects.length" description="暂无项目，点击新建项目开始管理" />
+  </section>
+
+  <el-dialog :title="dialogTitle" :model-value="dialogVisible" width="520px" @close="closeDialog">
+    <ProjectForm
+      :model-value="editingProject"
+      :submit-text="editingProject ? '保存修改' : '创建项目'"
+      :submitting="submitting"
+      @submit="handleSubmit"
+      @cancel="closeDialog"
+    />
+  </el-dialog>
+
+  <ConfirmDialog
+    :visible="deleteDialogVisible"
+    title="删除项目"
+    description="确定删除该项目吗？项目及其子项目将被隐藏。"
+    confirm-text="确认删除"
+    :loading="submitting"
+    @confirm="handleDelete"
+    @cancel="deleteDialogVisible = false"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { useRouter } from "vue-router";
+import { ElMessage } from "element-plus";
+import { TrendCharts, Tickets, Plus } from "@element-plus/icons-vue";
+import ProjectCard from "@/components/project/ProjectCard.vue";
+import ProjectForm from "@/components/project/ProjectForm.vue";
+import ProjectSearch from "@/components/project/ProjectSearch.vue";
+import LoadingSpinner from "@/components/common/LoadingSpinner.vue";
+import ConfirmDialog from "@/components/common/ConfirmDialog.vue";
+import { useProjects } from "@/composables/useProjects";
+import type { Project } from "@/types";
+
+const router = useRouter();
+const { filteredProjects, fetchProjects, createProject, updateProject, deleteProject, searchQuery, loading, projectStats } =
+  useProjects();
+
+const dialogVisible = ref(false);
+const deleteDialogVisible = ref(false);
+const editingProject = ref<Project | null>(null);
+const deletingProject = ref<Project | null>(null);
+const submitting = ref(false);
+
+const dialogTitle = computed(() => (editingProject.value ? "编辑项目" : "新建项目"));
+
+const openCreateDialog = () => {
+  editingProject.value = null;
+  dialogVisible.value = true;
+};
+
+const openEditDialog = (project: Project) => {
+  editingProject.value = project;
+  dialogVisible.value = true;
+};
+
+const closeDialog = () => {
+  dialogVisible.value = false;
+  editingProject.value = null;
+};
+
+const handleSubmit = async (payload: { name: string; description?: string | null }) => {
+  submitting.value = true;
+  try {
+    if (editingProject.value) {
+      await updateProject(editingProject.value.id, payload);
+      ElMessage.success("项目更新成功");
+    } else {
+      await createProject(payload);
+      ElMessage.success("项目创建成功");
+    }
+    closeDialog();
+  } catch (error) {
+    ElMessage.error("操作失败，请稍后重试");
+  } finally {
+    submitting.value = false;
+  }
+};
+
+const goProjectDetail = (id: number) => {
+  router.push({ name: "ProjectDetail", params: { id } });
+};
+
+const confirmDelete = (project: Project) => {
+  deletingProject.value = project;
+  deleteDialogVisible.value = true;
+};
+
+const handleDelete = async () => {
+  if (!deletingProject.value) return;
+  submitting.value = true;
+  try {
+    await deleteProject(deletingProject.value.id);
+    ElMessage.success("项目已删除");
+  } catch (error) {
+    ElMessage.error("删除失败，请重试");
+  } finally {
+    submitting.value = false;
+    deleteDialogVisible.value = false;
+    deletingProject.value = null;
+  }
+};
+
+onMounted(() => {
+  fetchProjects();
+});
+</script>

--- a/src/views/SubProjectDetail.vue
+++ b/src/views/SubProjectDetail.vue
@@ -1,0 +1,388 @@
+<template>
+  <section v-if="subProject" class="space-y-6">
+    <el-page-header @back="goBack">
+      <template #content>
+        <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-2xl font-semibold text-slate-900">{{ subProject.name }}</h2>
+            <p class="text-sm text-slate-500">{{ subProject.description || "暂无描述" }}</p>
+          </div>
+          <div class="flex items-center gap-3 text-xs text-slate-500">
+            <span class="flex items-center gap-1">
+              <el-icon><Timer /></el-icon>
+              更新于 {{ formatDate(subProject.updatedAt) }}
+            </span>
+            <span class="flex items-center gap-1">
+              <el-icon><Document /></el-icon>
+              内容 {{ subProject.contents.length }}
+            </span>
+            <span class="flex items-center gap-1">
+              <el-icon><Tickets /></el-icon>
+              文字口令 {{ subProject.textCommands.length }}
+            </span>
+          </div>
+        </div>
+      </template>
+    </el-page-header>
+
+    <el-card shadow="never" body-class="flex flex-wrap gap-3">
+      <el-button type="primary" @click="openSubProjectDialog">
+        <el-icon class="mr-1"><Edit /></el-icon>
+        编辑子项目
+      </el-button>
+      <el-button type="primary" plain @click="openContentDialog()">
+        <el-icon class="mr-1"><Plus /></el-icon>
+        新增内容
+      </el-button>
+      <el-button type="primary" plain @click="openCommandDialog()">
+        <el-icon class="mr-1"><ChatLineSquare /></el-icon>
+        新增口令
+      </el-button>
+    </el-card>
+
+    <el-card shadow="never" body-class="space-y-3">
+      <div class="flex items-center justify-between">
+        <h3 class="text-base font-semibold text-slate-800">内容列表</h3>
+        <el-button type="primary" link @click="openContentDialog()">
+          <el-icon class="mr-1"><Plus /></el-icon>新增内容
+        </el-button>
+      </div>
+      <el-empty v-if="!subProject.contents.length" description="暂无内容" />
+      <el-timeline v-else>
+        <el-timeline-item
+          v-for="content in subProject.contents"
+          :key="content.id"
+          :timestamp="formatDate(content.updatedAt)"
+          placement="top"
+        >
+          <div class="rounded-lg border border-slate-200 bg-white p-3">
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-2">
+                <el-tag effect="dark">{{ content.contentType.name }}</el-tag>
+                <ExpiryStatus v-if="content.expiryDate" :expiry-date="content.expiryDate" size="small" />
+              </div>
+              <div class="flex items-center gap-2 text-sm">
+                <el-button type="primary" link size="small" @click="openContentDialog(content)">编辑</el-button>
+                <el-button type="danger" link size="small" @click="confirmDeleteContent(content)">删除</el-button>
+              </div>
+            </div>
+            <p class="mt-2 whitespace-pre-wrap break-words text-sm text-slate-700">{{ content.contentValue }}</p>
+          </div>
+        </el-timeline-item>
+      </el-timeline>
+    </el-card>
+
+    <TextCommandList
+      :commands="subProject.textCommands"
+      @add="openCommandDialog"
+      @edit="openCommandDialog"
+      @delete="confirmDeleteCommand"
+    />
+  </section>
+  <el-empty v-else description="子项目不存在">
+    <el-button type="primary" @click="goBack">返回</el-button>
+  </el-empty>
+
+  <el-dialog title="编辑子项目" :model-value="subProjectDialogVisible" width="520px" @close="closeSubProjectDialog">
+    <SubProjectForm
+      v-if="subProjectDialogVisible"
+      :model-value="subProject"
+      :submit-text="'保存修改'"
+      :submitting="submitting"
+      @submit="handleSubProjectSubmit"
+      @cancel="closeSubProjectDialog"
+    />
+  </el-dialog>
+
+  <el-dialog :title="contentDialogTitle" :model-value="contentDialogVisible" width="560px" @close="closeContentDialog">
+    <ContentEditor
+      v-if="contentDialogVisible"
+      :content-types="contentTypes"
+      :model-value="editingContent"
+      :submit-text="editingContent ? '保存内容' : '新增内容'"
+      :submitting="submitting"
+      @submit="handleContentSubmit"
+      @cancel="closeContentDialog"
+    />
+  </el-dialog>
+
+  <el-dialog title="文字口令" :model-value="commandDialogVisible" width="520px" @close="closeCommandDialog">
+    <el-form ref="commandFormRef" :model="commandForm" :rules="commandRules" label-width="100px">
+      <el-form-item label="口令内容" prop="commandText">
+        <el-input v-model="commandForm.commandText" type="textarea" :autosize="{ minRows: 3, maxRows: 5 }" />
+      </el-form-item>
+      <el-form-item label="有效天数" prop="expiryDays">
+        <el-input-number v-model="commandForm.expiryDays" :min="1" :max="180" />
+      </el-form-item>
+    </el-form>
+    <template #footer>
+      <div class="flex justify-end gap-3">
+        <el-button @click="closeCommandDialog">取消</el-button>
+        <el-button type="primary" :loading="submitting" @click="handleCommandSubmit">
+          {{ editingCommand ? "保存口令" : "新增口令" }}
+        </el-button>
+      </div>
+    </template>
+  </el-dialog>
+
+  <ConfirmDialog
+    :visible="deleteContentDialogVisible"
+    title="删除内容"
+    description="确认删除该内容吗？"
+    confirm-text="确认删除"
+    :loading="submitting"
+    @confirm="handleContentDelete"
+    @cancel="handleCancelDeleteContent"
+  />
+
+  <ConfirmDialog
+    :visible="deleteCommandDialogVisible"
+    title="删除文字口令"
+    description="确认删除该文字口令吗？"
+    confirm-text="确认删除"
+    :loading="submitting"
+    @confirm="handleCommandDelete"
+    @cancel="handleCancelDeleteCommand"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from "vue";
+import { storeToRefs } from "pinia";
+import { useRoute, useRouter } from "vue-router";
+import { ElMessage } from "element-plus";
+import type { FormInstance, FormRules } from "element-plus";
+import {
+  Timer,
+  Document,
+  Tickets,
+  Edit,
+  Plus,
+  ChatLineSquare,
+} from "@element-plus/icons-vue";
+import { useDateFormat } from "@/composables/useDateFormat";
+import { useSubProjectsStore } from "@/stores/subProjects";
+import { useContentsStore } from "@/stores/contents";
+import SubProjectForm from "@/components/subproject/SubProjectForm.vue";
+import ContentEditor from "@/components/content/ContentEditor.vue";
+import TextCommandList from "@/components/content/TextCommandList.vue";
+import ConfirmDialog from "@/components/common/ConfirmDialog.vue";
+import ExpiryStatus from "@/components/content/ExpiryStatus.vue";
+import type { SubProjectContent, TextCommand } from "@/types";
+
+const route = useRoute();
+const router = useRouter();
+const { formatDate } = useDateFormat();
+
+const subProjectsStore = useSubProjectsStore();
+const contentsStore = useContentsStore();
+const { contentTypes } = storeToRefs(contentsStore);
+
+const projectId = Number(route.params.projectId);
+const subProjectId = Number(route.params.id);
+const subProject = computed(() => subProjectsStore.getSubProjectById(subProjectId));
+
+const submitting = ref(false);
+const editingContent = ref<SubProjectContent | null>(null);
+const deleteContentTarget = ref<SubProjectContent | null>(null);
+const editingCommand = ref<TextCommand | null>(null);
+const deleteCommandTarget = ref<TextCommand | null>(null);
+
+const commandFormRef = ref<FormInstance>();
+const commandForm = reactive({
+  commandText: "",
+  expiryDays: 7,
+});
+
+const commandRules: FormRules = {
+  commandText: [{ required: true, message: "请输入口令内容", trigger: "blur" }],
+  expiryDays: [{ required: true, message: "请输入有效天数", trigger: "change" }],
+};
+
+const dialogStates = reactive({
+  subProject: false,
+  content: false,
+  command: false,
+  deleteContent: false,
+  deleteCommand: false,
+});
+
+const subProjectDialogVisible = computed({
+  get: () => dialogStates.subProject,
+  set: (value: boolean) => (dialogStates.subProject = value),
+});
+const contentDialogVisible = computed({
+  get: () => dialogStates.content,
+  set: (value: boolean) => (dialogStates.content = value),
+});
+const commandDialogVisible = computed({
+  get: () => dialogStates.command,
+  set: (value: boolean) => (dialogStates.command = value),
+});
+const deleteContentDialogVisible = computed({
+  get: () => dialogStates.deleteContent,
+  set: (value: boolean) => (dialogStates.deleteContent = value),
+});
+const deleteCommandDialogVisible = computed({
+  get: () => dialogStates.deleteCommand,
+  set: (value: boolean) => (dialogStates.deleteCommand = value),
+});
+
+const contentDialogTitle = computed(() => (editingContent.value ? "编辑内容" : "新增内容"));
+
+const fetchDetail = async () => {
+  await Promise.all([
+    subProjectsStore.ensureSubProjectsForProject(projectId),
+    contentsStore.fetchContentTypes(),
+  ]);
+};
+
+const goBack = () => {
+  router.push({ name: "ProjectDetail", params: { id: projectId } });
+};
+
+const openSubProjectDialog = () => {
+  subProjectDialogVisible.value = true;
+};
+
+const closeSubProjectDialog = () => {
+  subProjectDialogVisible.value = false;
+};
+
+const handleSubProjectSubmit = async (payload: { name: string; description?: string; sortOrder: number }) => {
+  if (!subProject.value) return;
+  submitting.value = true;
+  try {
+    await subProjectsStore.updateSubProject(subProject.value.id, payload);
+    ElMessage.success("子项目更新成功");
+    closeSubProjectDialog();
+  } catch (error) {
+    ElMessage.error("更新子项目失败");
+  } finally {
+    submitting.value = false;
+  }
+};
+
+const openContentDialog = (content?: SubProjectContent) => {
+  editingContent.value = content ?? null;
+  contentDialogVisible.value = true;
+};
+
+const closeContentDialog = () => {
+  contentDialogVisible.value = false;
+  editingContent.value = null;
+};
+
+const handleContentSubmit = async (payload: { contentTypeId: number; contentValue: string; expiryDays?: number }) => {
+  if (!subProject.value) return;
+  submitting.value = true;
+  try {
+    if (editingContent.value) {
+      await contentsStore.updateContent(subProject.value.id, editingContent.value.id, payload);
+      ElMessage.success("内容更新成功");
+    } else {
+      await contentsStore.addContent(subProject.value.id, payload);
+      ElMessage.success("内容新增成功");
+    }
+    closeContentDialog();
+  } catch (error) {
+    ElMessage.error("内容操作失败");
+  } finally {
+    submitting.value = false;
+  }
+};
+
+const confirmDeleteContent = (content: SubProjectContent) => {
+  deleteContentTarget.value = content;
+  deleteContentDialogVisible.value = true;
+};
+
+const handleContentDelete = async () => {
+  if (!deleteContentTarget.value || !subProject.value) return;
+  submitting.value = true;
+  try {
+    await contentsStore.removeContent(subProject.value.id, deleteContentTarget.value.id);
+    ElMessage.success("内容已删除");
+  } catch (error) {
+    ElMessage.error("删除内容失败");
+  } finally {
+    submitting.value = false;
+    deleteContentDialogVisible.value = false;
+    deleteContentTarget.value = null;
+  }
+};
+
+const openCommandDialog = (command?: TextCommand) => {
+  editingCommand.value = command ?? null;
+  commandForm.commandText = command?.commandText ?? "";
+  commandForm.expiryDays = command?.expiryDays ?? 7;
+  commandDialogVisible.value = true;
+};
+
+const closeCommandDialog = () => {
+  commandDialogVisible.value = false;
+  editingCommand.value = null;
+  commandForm.commandText = "";
+  commandForm.expiryDays = 7;
+  commandFormRef.value?.clearValidate();
+};
+
+const handleCommandSubmit = async () => {
+  if (!commandFormRef.value || !subProject.value) return;
+  const valid = await commandFormRef.value.validate().catch(() => false);
+  if (!valid) return;
+  submitting.value = true;
+  try {
+    if (editingCommand.value) {
+      await contentsStore.updateTextCommand(subProject.value.id, editingCommand.value.id, {
+        commandText: commandForm.commandText,
+        expiryDays: commandForm.expiryDays,
+      });
+      ElMessage.success("口令更新成功");
+    } else {
+      await contentsStore.addTextCommand(subProject.value.id, {
+        commandText: commandForm.commandText,
+        expiryDays: commandForm.expiryDays,
+      });
+      ElMessage.success("口令新增成功");
+    }
+    closeCommandDialog();
+  } catch (error) {
+    ElMessage.error("口令操作失败");
+  } finally {
+    submitting.value = false;
+  }
+};
+
+const confirmDeleteCommand = (command: TextCommand) => {
+  deleteCommandTarget.value = command;
+  deleteCommandDialogVisible.value = true;
+};
+
+const handleCommandDelete = async () => {
+  if (!deleteCommandTarget.value || !subProject.value) return;
+  submitting.value = true;
+  try {
+    await contentsStore.removeTextCommand(subProject.value.id, deleteCommandTarget.value.id);
+    ElMessage.success("口令已删除");
+  } catch (error) {
+    ElMessage.error("删除口令失败");
+  } finally {
+    submitting.value = false;
+    deleteCommandDialogVisible.value = false;
+    deleteCommandTarget.value = null;
+  }
+};
+
+const handleCancelDeleteContent = () => {
+  deleteContentDialogVisible.value = false;
+  deleteContentTarget.value = null;
+};
+
+const handleCancelDeleteCommand = () => {
+  deleteCommandDialogVisible.value = false;
+  deleteCommandTarget.value = null;
+};
+
+onMounted(fetchDetail);
+</script>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{vue,ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: "#2563eb",
+          50: "#eff6ff",
+          100: "#dbeafe",
+          200: "#bfdbfe",
+          500: "#3b82f6",
+          600: "#2563eb",
+          700: "#1d4ed8"
+        }
+      }
+    }
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "types": ["vite/client"],
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [{ "path": "tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath, URL } from "node:url";
+import vue from "@vitejs/plugin-vue";
+import vueJsx from "@vitejs/plugin-vue-jsx";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [vue(), vueJsx()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  server: {
+    host: "0.0.0.0",
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold the Vue 3 + TypeScript + Element Plus application with routing, state stores, utilities, and shared UI components for CPS project management
- implement project, sub-project, and content management views covering creation, editing, deletion, sorting, and expiry-aware command workflows backed by Pinia sample data
- build a content type management dashboard with expiry insights, reminder panels, and CRUD dialogs for dynamic content configuration

## Testing
- npm run build *(fails: vue-tsc not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cc3d835c3883209ed8edb84efee4da